### PR TITLE
✨ feat: add Team LP Generator demo

### DIFF
--- a/examples/hono-app/index.html
+++ b/examples/hono-app/index.html
@@ -87,6 +87,14 @@
             photo captions, budget analysis, and destination guides.
           </div>
         </a>
+        <a href="/team-lp/" class="card">
+          <div class="icon">&#x1F465;</div>
+          <h2>Team LP Generator</h2>
+          <div class="desc">
+            7 team LP recipes — hero sections, member cards,
+            achievements, culture &amp; values, project showcase, and full page assembly.
+          </div>
+        </a>
       </div>
     </div>
   </body>

--- a/examples/hono-app/src/client/team-lp/App.tsx
+++ b/examples/hono-app/src/client/team-lp/App.tsx
@@ -1,0 +1,879 @@
+import type { MaterialInput } from "@EdV4H/alchemy-react";
+import { useAlchemy } from "@EdV4H/alchemy-react";
+import { useCallback, useState } from "react";
+import { teamLpCatalystPresets } from "../../team-lp/catalysts.js";
+import { teamLpRecipeEntries } from "../../team-lp/recipes.js";
+import {
+  CustomDataForm,
+  CustomDocumentForm,
+  CustomImageForm,
+  CustomTextForm,
+  RecipeInfoPopover,
+} from "../shared/components.js";
+import { codeStyle, labelStyle } from "../shared/styles.js";
+import type { CustomMaterial, MaterialCard } from "../shared/types.js";
+
+// ─── Sample Materials ───────────────────────────────────────────────────────
+
+const allMaterials: MaterialCard[] = [
+  // ── Member Profiles ─────────────────────────────────────────────────────────
+  {
+    id: "member-alice",
+    icon: "\uD83D\uDC69\u200D\uD83D\uDCBB",
+    label: "Alice Chen — Tech Lead",
+    category: "text",
+    text: `Alice Chen — Tech Lead
+5+ years in distributed systems and cloud architecture. Led the migration of our core platform to microservices, reducing latency by 40%. Passionate about mentoring junior engineers and building scalable, resilient systems. Previously at Google Cloud and a YC startup. Skills: Go, Rust, Kubernetes, gRPC, PostgreSQL.`,
+  },
+  {
+    id: "member-bob",
+    icon: "\uD83D\uDC68\u200D\uD83C\uDFA8",
+    label: "Bob Tanaka — Design Lead",
+    category: "text",
+    text: `Bob Tanaka — Design Lead
+Award-winning UX/UI designer with 7 years of experience crafting intuitive products. Led the redesign of our dashboard that boosted user engagement by 60%. Advocates for accessibility-first design and design systems. Previously at IDEO and Figma. Skills: Figma, Framer, Design Systems, User Research, Prototyping.`,
+  },
+  {
+    id: "member-carol",
+    icon: "\uD83D\uDC69\u200D\uD83D\uDD2C",
+    label: "Carol Park — ML Engineer",
+    category: "text",
+    text: `Carol Park — ML Engineer
+Machine learning engineer specializing in NLP and recommendation systems. Built our real-time personalization engine that increased conversion by 25%. Published 3 papers at NeurIPS and ICML. Open source contributor to Hugging Face Transformers. Skills: Python, PyTorch, TensorFlow, MLOps, LLMs.`,
+  },
+
+  // ── Team Info ───────────────────────────────────────────────────────────────
+  {
+    id: "team-mission",
+    icon: "\uD83C\uDFAF",
+    label: "Team Mission & Vision",
+    category: "text",
+    text: `Mission: Empower every developer to build AI-powered applications with zero friction.
+Vision: A world where AI capabilities are as accessible as a REST API call.
+We believe in democratizing AI — making powerful machine learning tools available to teams of all sizes, not just tech giants.`,
+  },
+  {
+    id: "team-goals",
+    icon: "\uD83D\uDCCB",
+    label: "2025 Team Goals",
+    category: "text",
+    text: `2025 Team Goals:
+Q1: Launch v2.0 of the SDK with streaming support — KPI: 10,000 monthly active developers
+Q2: Expand to 3 new languages (Rust, Go, Swift) — KPI: 50% increase in non-JS usage
+Q3: Achieve SOC 2 compliance and enterprise readiness — KPI: 5 enterprise contracts signed
+Q4: Open-source core engine — KPI: 1,000 GitHub stars in first month
+Annual target: $5M ARR, 95% customer satisfaction, <50ms p99 latency.`,
+  },
+  {
+    id: "culture-notes",
+    icon: "\uD83C\uDF31",
+    label: "Team Culture Notes",
+    category: "text",
+    text: `Team Culture:
+• Async-first: We default to asynchronous communication. Meetings are the exception, not the rule.
+• Hackathon Fridays: Every other Friday is dedicated to exploring new ideas and prototypes.
+• Open-source Friday: Contribute back to the community on alternating Fridays.
+• Blameless post-mortems: We learn from failures without finger-pointing.
+• Documentation culture: If it's not documented, it doesn't exist.
+• Remote-friendly: Team members across 4 time zones (US, Europe, Japan, Korea).
+• Core values: Curiosity, Craftsmanship, Collaboration, Courage.`,
+  },
+
+  // ── Photos ──────────────────────────────────────────────────────────────────
+  {
+    id: "team-photo",
+    icon: "\uD83D\uDCF8",
+    label: "Team Photo",
+    category: "image",
+    text: "A team group photo showing the diverse, energetic team in a modern office environment.",
+    imageUrl: "https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=800",
+  },
+  {
+    id: "workspace-photo",
+    icon: "\uD83C\uDFE2",
+    label: "Workspace Photo",
+    category: "image",
+    text: "A modern, open-plan workspace with standing desks, whiteboards, and natural light.",
+    imageUrl: "https://images.unsplash.com/photo-1497366216548-37526070297c?w=800",
+  },
+  {
+    id: "team-logo",
+    icon: "\uD83C\uDFA8",
+    label: "Team Logo",
+    category: "image",
+    text: "Team logo — a modern, minimal tech brand mark.",
+    imageUrl: "https://images.unsplash.com/photo-1599305445671-ac291c95aaa9?w=800",
+  },
+
+  // ── Data ────────────────────────────────────────────────────────────────────
+  {
+    id: "achievements-csv",
+    icon: "\uD83D\uDCCA",
+    label: "Team Achievements CSV",
+    category: "data",
+    text: "Team metrics and achievements data (CSV)",
+    dataFormat: "csv",
+    dataContent:
+      "metric,value,unit,period\nMonthly Active Users,125000,users,2024-Q4\nPlatform Uptime,99.97,%,2024\nCustomer NPS,72,score,2024-Q4\nDeploy Frequency,47,deploys/week,2024-Q4\nMean Time to Recovery,4.2,minutes,2024-Q4\nCode Coverage,94,%,2024-Q4\nOpen Source Stars,8500,stars,2024-12\nTeam Satisfaction,4.6,/5.0,2024-Q4",
+  },
+  {
+    id: "projects-json",
+    icon: "\uD83D\uDE80",
+    label: "Project Portfolio JSON",
+    category: "data",
+    text: "Project portfolio data (JSON)",
+    dataFormat: "json",
+    dataContent: JSON.stringify(
+      [
+        {
+          name: "Alchemy SDK v2",
+          challenge: "Developers struggled with complex ML pipelines requiring deep AI expertise",
+          solution:
+            "Built an intuitive SDK with recipe-based abstractions, streaming support, and auto-optimization",
+          result: "10,000+ monthly active developers, 4.8/5 satisfaction score",
+          tech: ["TypeScript", "Node.js", "OpenAI", "Streaming API"],
+        },
+        {
+          name: "Real-time Personalization Engine",
+          challenge: "E-commerce partners needed sub-100ms personalized recommendations at scale",
+          solution: "Designed a hybrid collaborative filtering + LLM system with edge caching",
+          result: "25% increase in conversion rate, <50ms p99 latency",
+          tech: ["Python", "PyTorch", "Redis", "Kubernetes"],
+        },
+        {
+          name: "Design System 'Aurora'",
+          challenge:
+            "Inconsistent UI across 12 products led to poor user experience and slow development",
+          solution:
+            "Created a comprehensive design system with 80+ components, accessibility baked in",
+          result: "60% faster feature development, WCAG AA compliance across all products",
+          tech: ["React", "Figma", "Storybook", "CSS Variables"],
+        },
+      ],
+      null,
+      2,
+    ),
+  },
+
+  // ── Documents ───────────────────────────────────────────────────────────────
+  {
+    id: "company-overview",
+    icon: "\uD83D\uDCC4",
+    label: "Company Overview",
+    category: "document",
+    text: "Company overview document",
+    documentText: `# Alchemy Labs — Company Overview
+
+## About Us
+Alchemy Labs is a Series A startup (founded 2022) building the developer platform for AI-native applications. Our tools help engineering teams integrate large language models, computer vision, and ML pipelines into their products without requiring PhD-level AI expertise.
+
+## Key Numbers
+- Founded: 2022
+- Team Size: 28 people across 6 countries
+- Funding: $12M Series A (Sequoia, a16z)
+- Customers: 200+ companies including 5 Fortune 500
+
+## Products
+1. **Alchemy SDK** — Open-source toolkit for building AI-powered features
+2. **Alchemy Cloud** — Managed infrastructure for ML model serving
+3. **Alchemy Studio** — No-code AI workflow builder for non-technical teams
+
+## Awards & Recognition
+- ProductHunt #1 Product of the Day (March 2024)
+- Forbes 30 Under 30 — Alice Chen (2024)
+- Best Developer Tool — DevWorld Conference 2024`,
+  },
+];
+
+// ─── Category groups for the material shelf ─────────────────────────────────
+
+const materialGroups: { header: string; filter: (m: MaterialCard) => boolean }[] = [
+  { header: "\uD83D\uDC64 Member Profiles", filter: (m) => m.id.startsWith("member-") },
+  {
+    header: "\uD83D\uDCDD Team Info",
+    filter: (m) => m.category === "text" && !m.id.startsWith("member-"),
+  },
+  { header: "\uD83D\uDCF7 Photos", filter: (m) => m.category === "image" },
+  { header: "\uD83D\uDCCA Data", filter: (m) => m.category === "data" },
+  { header: "\uD83D\uDCC4 Documents", filter: (m) => m.category === "document" },
+];
+
+// ─── App ────────────────────────────────────────────────────────────────────
+
+export function App() {
+  const alchemy = useAlchemy({ initialRecipeId: teamLpRecipeEntries[0].recipe.id });
+  const [customMaterials, setCustomMaterials] = useState<CustomMaterial[]>([]);
+  const [showForm, setShowForm] = useState<"text" | "image" | "data" | "document" | null>(null);
+  const [infoPopoverId, setInfoPopoverId] = useState<string | null>(null);
+
+  const {
+    selectedRecipeId,
+    selectedIds,
+    selectedCatalystKey,
+    selectedLanguage,
+    compareMode,
+    selectedCompareKeys,
+    result,
+    compareResults,
+    isLoading,
+    error,
+  } = alchemy;
+
+  const selectedEntry = teamLpRecipeEntries.find((e) => e.recipe.id === selectedRecipeId);
+
+  const allSelectableMaterials: (MaterialCard | (CustomMaterial & { icon: string }))[] = [
+    ...allMaterials,
+    ...customMaterials.map((c) => ({
+      ...c,
+      icon:
+        c.type === "data"
+          ? "\uD83D\uDCCA"
+          : c.type === "document"
+            ? "\uD83D\uDCC4"
+            : c.type === "image"
+              ? "\uD83D\uDDBC\uFE0F"
+              : "\uD83D\uDCDD",
+    })),
+  ];
+
+  const selectedMaterials = allSelectableMaterials.filter((m) => selectedIds.has(m.id));
+
+  const addCustomMaterial = (m: CustomMaterial) => {
+    setCustomMaterials((prev) => [...prev, m]);
+    setShowForm(null);
+  };
+
+  const removeCustomMaterial = (id: string) => {
+    setCustomMaterials((prev) => prev.filter((m) => m.id !== id));
+    alchemy.toggleMaterial(id);
+  };
+
+  const buildMaterialInputs = useCallback((): MaterialInput[] => {
+    return selectedMaterials.flatMap((m): MaterialInput[] => {
+      const category = "category" in m ? m.category : undefined;
+      if (category === "data" || ("type" in m && m.type === "data")) {
+        const dc = "dataContent" in m ? m.dataContent : undefined;
+        const df = "dataFormat" in m ? m.dataFormat : undefined;
+        if (dc && df) {
+          return [{ type: "data", dataFormat: df, dataContent: dc, dataLabel: m.label }];
+        }
+      } else if (category === "document" || ("type" in m && m.type === "document")) {
+        const dt = "documentText" in m ? m.documentText : undefined;
+        if (dt) {
+          return [{ type: "document", documentText: dt }];
+        }
+      } else {
+        const inputs: MaterialInput[] = [];
+        if ("text" in m && m.text) inputs.push({ type: "text", text: m.text });
+        if ("imageUrl" in m && m.imageUrl) inputs.push({ type: "image", imageUrl: m.imageUrl });
+        return inputs;
+      }
+      return [];
+    });
+  }, [selectedMaterials]);
+
+  const handleTransmute = useCallback(
+    () => alchemy.transmute(buildMaterialInputs()),
+    [alchemy.transmute, buildMaterialInputs],
+  );
+
+  const handleCompare = useCallback(
+    () => alchemy.compare(buildMaterialInputs()),
+    [alchemy.compare, buildMaterialInputs],
+  );
+
+  const hasSelection = selectedMaterials.length > 0;
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif" }}>
+      <div
+        style={{
+          maxWidth: 1280,
+          margin: "0 auto",
+          padding: "40px 24px",
+          display: "grid",
+          gridTemplateColumns: "1fr 420px",
+          gap: 32,
+          alignItems: "start",
+        }}
+      >
+        {/* Left: Recipe + Transmute */}
+        <div>
+          <h1>Team LP Generator</h1>
+          <p style={{ color: "#888", marginTop: -8, marginBottom: 16, fontSize: 14 }}>
+            {"\u30C1\u30FC\u30E0LP\u3092\u932C\u91D1\u3059\u308B"}
+          </p>
+
+          {/* Recipe selector */}
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", margin: "16px 0" }}>
+            {teamLpRecipeEntries.map((entry) => {
+              const active = entry.recipe.id === selectedRecipeId;
+              return (
+                <button
+                  type="button"
+                  key={entry.recipe.id}
+                  onClick={() => {
+                    alchemy.selectRecipe(entry.recipe.id);
+                    setInfoPopoverId(null);
+                  }}
+                  style={{
+                    padding: "6px 14px",
+                    fontSize: 14,
+                    borderRadius: 20,
+                    border: active ? "2px solid #333" : "1px solid #ccc",
+                    background: active ? "#333" : "#fff",
+                    color: active ? "#fff" : "#333",
+                    cursor: "pointer",
+                  }}
+                >
+                  {entry.icon} {entry.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {selectedEntry && (
+            <div style={{ position: "relative", margin: "4px 0 16px" }}>
+              <p style={{ color: "#666", margin: 0, display: "inline" }}>
+                {selectedEntry.description}
+              </p>
+              <button
+                type="button"
+                onClick={() =>
+                  setInfoPopoverId(
+                    infoPopoverId === selectedEntry.recipe.id ? null : selectedEntry.recipe.id,
+                  )
+                }
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: "#999",
+                  cursor: "pointer",
+                  fontSize: 13,
+                  padding: "0 0 0 6px",
+                  verticalAlign: "baseline",
+                  textDecoration: "underline",
+                  textDecorationStyle: "dotted",
+                  textUnderlineOffset: 2,
+                }}
+              >
+                details
+              </button>
+              {infoPopoverId === selectedEntry.recipe.id && (
+                <RecipeInfoPopover entry={selectedEntry} onClose={() => setInfoPopoverId(null)} />
+              )}
+            </div>
+          )}
+
+          {/* Catalyst selector */}
+          <div style={{ margin: "0 0 16px" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <span style={{ ...labelStyle, margin: 0 }}>Catalyst</span>
+              <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!compareMode) {
+                      alchemy.selectCatalyst(null);
+                      alchemy.resetResults();
+                    }
+                  }}
+                  style={{
+                    padding: "4px 12px",
+                    fontSize: 12,
+                    borderRadius: 14,
+                    border:
+                      !compareMode && selectedCatalystKey === null
+                        ? "2px solid #333"
+                        : "1px solid #ccc",
+                    background: !compareMode && selectedCatalystKey === null ? "#333" : "#fff",
+                    color: !compareMode && selectedCatalystKey === null ? "#fff" : "#555",
+                    cursor: "pointer",
+                  }}
+                >
+                  Default
+                </button>
+                {teamLpCatalystPresets.map((cat) => {
+                  const isSelected = compareMode
+                    ? selectedCompareKeys.includes(cat.key)
+                    : selectedCatalystKey === cat.key;
+                  return (
+                    <button
+                      type="button"
+                      key={cat.key}
+                      onClick={() => {
+                        if (compareMode) {
+                          alchemy.toggleCompareKey(cat.key);
+                        } else {
+                          alchemy.selectCatalyst(cat.key);
+                          alchemy.resetResults();
+                        }
+                      }}
+                      style={{
+                        padding: "4px 12px",
+                        fontSize: 12,
+                        borderRadius: 14,
+                        border: isSelected ? "2px solid #333" : "1px solid #ccc",
+                        background: isSelected ? "#333" : "#fff",
+                        color: isSelected ? "#fff" : "#555",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {cat.label}
+                    </button>
+                  );
+                })}
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, marginLeft: "auto" }}>
+                <span style={{ fontSize: 12, color: "#888" }}>Language</span>
+                <select
+                  value={selectedLanguage ?? ""}
+                  onChange={(e) => alchemy.setLanguage(e.target.value || null)}
+                  style={{
+                    padding: "3px 6px",
+                    fontSize: 12,
+                    borderRadius: 4,
+                    border: "1px solid #ccc",
+                    background: "#fff",
+                    color: "#333",
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="">Auto</option>
+                  <option value="English">English</option>
+                  <option value="Japanese">日本語</option>
+                  <option value="Chinese">中文</option>
+                  <option value="Korean">한국어</option>
+                </select>
+                <label
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 4,
+                    fontSize: 12,
+                    color: "#888",
+                    cursor: "pointer",
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={compareMode}
+                    onChange={(e) => {
+                      const on = e.target.checked;
+                      alchemy.setCompareMode(on);
+                      alchemy.resetResults();
+                      if (on) {
+                        alchemy.setCompareKeys(teamLpCatalystPresets.map((c) => c.key));
+                      }
+                    }}
+                  />
+                  Compare
+                </label>
+              </div>
+            </div>
+          </div>
+
+          {/* Selected materials preview */}
+          {hasSelection ? (
+            <div
+              style={{
+                border: "1px solid #e0e0e0",
+                borderRadius: 6,
+                padding: 16,
+                marginBottom: 16,
+              }}
+            >
+              <div
+                style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}
+              >
+                <span style={labelStyle}>Materials ({selectedMaterials.length})</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    alchemy.clearSelection();
+                    alchemy.resetResults();
+                  }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: "#999",
+                    cursor: "pointer",
+                    fontSize: 12,
+                    padding: 0,
+                  }}
+                >
+                  Clear all
+                </button>
+              </div>
+              {selectedMaterials.map((mat) => {
+                const imageUrl = "imageUrl" in mat ? mat.imageUrl : undefined;
+                const text = "text" in mat ? mat.text : undefined;
+                return (
+                  <div key={mat.id} style={{ marginTop: 12 }}>
+                    <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4 }}>
+                      {mat.icon} {mat.label}
+                    </div>
+                    {imageUrl && (
+                      <img
+                        src={imageUrl}
+                        alt="Material"
+                        style={{
+                          maxWidth: "100%",
+                          maxHeight: 140,
+                          borderRadius: 4,
+                          border: "1px solid #e0e0e0",
+                          marginBottom: 6,
+                          display: "block",
+                        }}
+                      />
+                    )}
+                    {text && (
+                      <pre style={{ ...codeStyle, margin: 0, maxHeight: 80, fontSize: 12 }}>
+                        {text}
+                      </pre>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div
+              style={{
+                border: "1px dashed #ccc",
+                borderRadius: 6,
+                padding: "28px 16px",
+                textAlign: "center",
+                color: "#aaa",
+                fontSize: 14,
+                marginBottom: 16,
+              }}
+            >
+              {
+                "\u30C1\u30FC\u30E0\u306E\u7D20\u6750\u3092\u9078\u3093\u3067\u304F\u3060\u3055\u3044"
+              }{" "}
+              &rarr;
+            </div>
+          )}
+
+          {/* Transmute / Compare Button */}
+          {compareMode ? (
+            <button
+              type="button"
+              onClick={handleCompare}
+              disabled={isLoading || !hasSelection || selectedCompareKeys.length < 2}
+              style={{ marginTop: 8, padding: "8px 20px", fontSize: 14, cursor: "pointer" }}
+            >
+              {isLoading ? "Comparing..." : `Compare (${selectedCompareKeys.length} catalysts)`}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleTransmute}
+              disabled={isLoading || !hasSelection}
+              style={{ marginTop: 8, padding: "8px 20px", fontSize: 14, cursor: "pointer" }}
+            >
+              {isLoading ? "Transmuting..." : "Transmute"}
+            </button>
+          )}
+
+          {error && <p style={{ color: "red", marginTop: 12 }}>{error}</p>}
+
+          {/* Single result — HTML rendered */}
+          {result != null && (
+            <div style={{ marginTop: 24 }}>
+              <h2>Result</h2>
+              {typeof result === "string" ? (
+                <>
+                  <div
+                    style={{
+                      border: "1px solid #e0e0e0",
+                      borderRadius: 6,
+                      padding: 16,
+                      marginBottom: 12,
+                    }}
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: intentional HTML rendering from LLM output
+                    dangerouslySetInnerHTML={{ __html: result }}
+                  />
+                  <details>
+                    <summary style={{ cursor: "pointer", fontSize: 13, color: "#888" }}>
+                      View HTML Source
+                    </summary>
+                    <pre style={{ ...codeStyle, marginTop: 8, fontSize: 12 }}>{result}</pre>
+                  </details>
+                </>
+              ) : (
+                <pre style={codeStyle}>{JSON.stringify(result, null, 2)}</pre>
+              )}
+            </div>
+          )}
+
+          {/* Compare results — HTML rendered */}
+          {compareResults != null && (
+            <div style={{ marginTop: 24 }}>
+              <h2>Comparison</h2>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: `repeat(${Object.keys(compareResults).length}, 1fr)`,
+                  gap: 12,
+                }}
+              >
+                {Object.entries(compareResults).map(([key, val]) => {
+                  const catalystLabel =
+                    teamLpCatalystPresets.find((c) => c.key === key)?.label ?? key;
+                  return (
+                    <div
+                      key={key}
+                      style={{
+                        border: "1px solid #e0e0e0",
+                        borderRadius: 6,
+                        padding: 12,
+                        minWidth: 0,
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 600,
+                          color: "#555",
+                          marginBottom: 8,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.05em",
+                        }}
+                      >
+                        {catalystLabel}
+                      </div>
+                      {typeof val === "string" ? (
+                        <>
+                          <div
+                            style={{ fontSize: 13 }}
+                            // biome-ignore lint/security/noDangerouslySetInnerHtml: intentional HTML rendering from LLM output
+                            dangerouslySetInnerHTML={{ __html: val }}
+                          />
+                          <details style={{ marginTop: 8 }}>
+                            <summary style={{ cursor: "pointer", fontSize: 11, color: "#aaa" }}>
+                              HTML Source
+                            </summary>
+                            <pre
+                              style={{
+                                ...codeStyle,
+                                margin: "4px 0 0",
+                                fontSize: 10,
+                                maxHeight: 200,
+                              }}
+                            >
+                              {val}
+                            </pre>
+                          </details>
+                        </>
+                      ) : (
+                        <pre style={{ ...codeStyle, margin: 0, fontSize: 12 }}>
+                          {JSON.stringify(val, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Right: Material Shelf */}
+        <div
+          style={{
+            position: "sticky",
+            top: 24,
+            border: "1px solid #e0e0e0",
+            borderRadius: 6,
+            padding: 16,
+            marginTop: 56,
+          }}
+        >
+          <div style={{ ...labelStyle, marginBottom: 12 }}>Material Shelf</div>
+
+          {/* Grouped materials with category headers */}
+          {materialGroups.map((group) => {
+            const items = allMaterials.filter(group.filter);
+            if (items.length === 0) return null;
+            return (
+              <div key={group.header} style={{ marginBottom: 12 }}>
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: "#999",
+                    marginBottom: 6,
+                    paddingBottom: 2,
+                    borderBottom: "1px solid #f0f0f0",
+                  }}
+                >
+                  {group.header}
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+                  {items.map((mat) => {
+                    const active = selectedIds.has(mat.id);
+                    return (
+                      <button
+                        type="button"
+                        key={mat.id}
+                        onClick={() => alchemy.toggleMaterial(mat.id)}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 6,
+                          padding: "7px 8px",
+                          background: active ? "#f0f0f0" : "#fff",
+                          border: active ? "2px solid #333" : "1px solid #e0e0e0",
+                          borderRadius: 6,
+                          cursor: "pointer",
+                          color: "#333",
+                          textAlign: "left",
+                          fontSize: 12,
+                          overflow: "hidden",
+                        }}
+                      >
+                        <span style={{ fontSize: 14, flexShrink: 0 }}>{mat.icon}</span>
+                        <span
+                          style={{
+                            fontWeight: 500,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {mat.label}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Custom materials */}
+          {customMaterials.length > 0 && (
+            <>
+              <div style={{ ...labelStyle, marginTop: 16, marginBottom: 8 }}>Custom</div>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+                {customMaterials.map((mat) => {
+                  const active = selectedIds.has(mat.id);
+                  return (
+                    <div key={mat.id} style={{ display: "flex", gap: 2, alignItems: "center" }}>
+                      <button
+                        type="button"
+                        onClick={() => alchemy.toggleMaterial(mat.id)}
+                        style={{
+                          flex: 1,
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 6,
+                          padding: "7px 8px",
+                          background: active ? "#f0f0f0" : "#fff",
+                          border: active ? "2px solid #333" : "1px solid #e0e0e0",
+                          borderRadius: 6,
+                          cursor: "pointer",
+                          color: "#333",
+                          textAlign: "left",
+                          fontSize: 12,
+                          overflow: "hidden",
+                        }}
+                      >
+                        <span style={{ fontSize: 14, flexShrink: 0 }}>
+                          {mat.type === "data"
+                            ? "\uD83D\uDCCA"
+                            : mat.type === "document"
+                              ? "\uD83D\uDCC4"
+                              : mat.type === "image"
+                                ? "\uD83D\uDDBC\uFE0F"
+                                : "\uD83D\uDCDD"}
+                        </span>
+                        <span
+                          style={{
+                            fontWeight: 500,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {mat.label}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => removeCustomMaterial(mat.id)}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          color: "#999",
+                          cursor: "pointer",
+                          fontSize: 14,
+                          padding: "0 2px",
+                          lineHeight: 1,
+                          flexShrink: 0,
+                        }}
+                        title="Remove"
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {/* Add custom material buttons */}
+          <div style={{ marginTop: 16, borderTop: "1px solid #eee", paddingTop: 12 }}>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr 1fr", gap: 5 }}>
+              {(
+                [
+                  ["text", "+ Text"],
+                  ["image", "+ Image"],
+                  ["data", "+ Data"],
+                  ["document", "+ Doc"],
+                ] as const
+              ).map(([key, lbl]) => (
+                <button
+                  type="button"
+                  key={key}
+                  onClick={() => setShowForm(showForm === key ? null : key)}
+                  style={{
+                    padding: "5px 6px",
+                    fontSize: 11,
+                    cursor: "pointer",
+                    background: showForm === key ? "#f0f0f0" : "#fff",
+                    border: showForm === key ? "1px solid #999" : "1px solid #ddd",
+                    borderRadius: 4,
+                    color: "#555",
+                  }}
+                >
+                  {lbl}
+                </button>
+              ))}
+            </div>
+            {showForm === "text" && (
+              <CustomTextForm onAdd={addCustomMaterial} onCancel={() => setShowForm(null)} />
+            )}
+            {showForm === "image" && (
+              <CustomImageForm onAdd={addCustomMaterial} onCancel={() => setShowForm(null)} />
+            )}
+            {showForm === "data" && (
+              <CustomDataForm onAdd={addCustomMaterial} onCancel={() => setShowForm(null)} />
+            )}
+            {showForm === "document" && (
+              <CustomDocumentForm onAdd={addCustomMaterial} onCancel={() => setShowForm(null)} />
+            )}
+          </div>
+
+          {selectedIds.size > 0 && (
+            <div style={{ marginTop: 10, fontSize: 12, color: "#999", textAlign: "center" }}>
+              {selectedIds.size} selected
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/hono-app/src/client/team-lp/main.tsx
+++ b/examples/hono-app/src/client/team-lp/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+// biome-ignore lint/style/noNonNullAssertion: root element is guaranteed in index.html
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/hono-app/src/server/index.ts
+++ b/examples/hono-app/src/server/index.ts
@@ -11,6 +11,8 @@ import {
 import { Hono } from "hono";
 import { catalystPresets } from "../shared/catalysts.js";
 import { recipeRegistry } from "../shared/recipes.js";
+import { teamLpCatalystPresets } from "../team-lp/catalysts.js";
+import { teamLpRecipeRegistry } from "../team-lp/recipes.js";
 import { travelCatalystPresets } from "../travel/catalysts.js";
 import { travelRecipeRegistry } from "../travel/recipes.js";
 
@@ -38,12 +40,29 @@ travelRecipeRegistry["destination-guide"].transforms = [
   documentToText(),
 ];
 
+// Inject Node-specific transforms at server init (team-lp)
+teamLpRecipeRegistry["team-hero"].transforms = [imageUrlToBase64()];
+teamLpRecipeRegistry["team-members"].transforms = [imageUrlToBase64()];
+teamLpRecipeRegistry["team-achievements"].transforms = [
+  ...(teamLpRecipeRegistry["team-achievements"].transforms ?? []),
+  dataToText(),
+];
+teamLpRecipeRegistry["team-projects"].transforms = [
+  ...(teamLpRecipeRegistry["team-projects"].transforms ?? []),
+  dataToText(),
+];
+teamLpRecipeRegistry["team-full-page"].transforms = [imageUrlToBase64(), dataToText()];
+
 // Merge all recipes
 // biome-ignore lint/suspicious/noExplicitAny: recipe output types vary
-const allRecipes: Record<string, any> = { ...recipeRegistry, ...travelRecipeRegistry };
+const allRecipes: Record<string, any> = {
+  ...recipeRegistry,
+  ...travelRecipeRegistry,
+  ...teamLpRecipeRegistry,
+};
 
 // Merge all catalyst presets
-const allCatalystPresets = [...catalystPresets, ...travelCatalystPresets];
+const allCatalystPresets = [...catalystPresets, ...travelCatalystPresets, ...teamLpCatalystPresets];
 
 /**
  * Server-side MaterialInput extends core MaterialInput with documentUrl support.

--- a/examples/hono-app/src/team-lp/catalysts.ts
+++ b/examples/hono-app/src/team-lp/catalysts.ts
@@ -1,0 +1,51 @@
+import type { NamedCatalyst } from "@EdV4H/alchemy-node";
+
+/** チームLP用カタリストプリセット */
+export const teamLpCatalystPresets: NamedCatalyst[] = [
+  {
+    key: "corporate",
+    label: "Corporate / 企業向け",
+    isDefault: true,
+    config: {
+      roleDefinition:
+        "You are a professional corporate communications writer. Produce polished, trustworthy, and authoritative landing page content as semantic HTML with inline styles. Use a formal yet approachable tone that conveys credibility and reliability. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+      temperature: 0.4,
+    },
+  },
+  {
+    key: "startup",
+    label: "Startup / スタートアップ",
+    config: {
+      roleDefinition:
+        "You are an energetic startup storyteller. Write bold, dynamic landing page copy as semantic HTML with inline styles that radiates momentum and ambition. Use punchy sentences, action verbs, and a forward-looking tone that inspires excitement. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+      temperature: 0.6,
+    },
+  },
+  {
+    key: "creative",
+    label: "Creative / クリエイティブ",
+    config: {
+      roleDefinition:
+        "You are an avant-garde creative director. Craft landing page content as semantic HTML with inline styles that feels like art — unexpected metaphors, playful typography hints, and visually expressive language. Push boundaries while staying readable. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+      temperature: 0.8,
+    },
+  },
+  {
+    key: "minimal",
+    label: "Minimal / ミニマル",
+    config: {
+      roleDefinition:
+        "You are a minimalist design writer producing semantic HTML with inline styles. Every word must earn its place. Use ultra-concise copy, generous whitespace hints, and the fewest possible words to convey maximum meaning. Less is more. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+      temperature: 0.3,
+    },
+  },
+  {
+    key: "friendly",
+    label: "Friendly / フレンドリー",
+    config: {
+      roleDefinition:
+        "You are a warm, personable team culture writer. Create landing page content as semantic HTML with inline styles that feels like a conversation with a friend — casual, genuine, and inviting. Use inclusive language and a welcoming tone. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+      temperature: 0.7,
+    },
+  },
+];

--- a/examples/hono-app/src/team-lp/recipes.ts
+++ b/examples/hono-app/src/team-lp/recipes.ts
@@ -1,0 +1,240 @@
+import type { MaterialPart, Recipe } from "@EdV4H/alchemy-node";
+import { extractText, TextRefiner, truncateText } from "@EdV4H/alchemy-node";
+import type { RecipeEntry } from "../shared/recipes.js";
+
+// ─── Recipe 1: Hero Section ─────────────────────────────────────────────────
+// ヒーローセクション — HTML output
+
+export const teamHeroRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-hero",
+  name: "Hero Section",
+  catalyst: {
+    roleDefinition:
+      "You are an expert landing page designer. Generate a compelling hero section as semantic HTML with inline styles. Include a headline, tagline, mission statement, and a call-to-action button. Use modern, responsive CSS. If a response language is specified, write all visible text content (headings, paragraphs, buttons) in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+    temperature: 0.5,
+  },
+  spell: (parts) => [
+    {
+      type: "text",
+      text: "Using the following team materials, generate a hero section for a team landing page as a single HTML fragment with inline styles. Include: a bold headline, a tagline, a brief mission statement, and a CTA button. Make it visually striking:",
+    },
+    ...parts,
+  ],
+  refiner: new TextRefiner(),
+};
+
+// ─── Recipe 2: Member Profile Cards ─────────────────────────────────────────
+// メンバーカードグリッド — HTML output
+
+export const teamMembersRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-members",
+  name: "Member Profile Cards",
+  catalyst: {
+    roleDefinition:
+      "You are a UI designer specializing in profile cards. Generate a responsive grid of member profile cards as semantic HTML with inline styles. Each card should include the member's name, role, a brief bio, and skills. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+    temperature: 0.5,
+  },
+  spell: (parts) => [
+    {
+      type: "text",
+      text: "Using the following team member profiles, generate a responsive card grid as HTML with inline styles. Each card should display: name, role/title, a short bio, and key skills or expertise areas:",
+    },
+    ...parts,
+  ],
+  refiner: new TextRefiner(),
+};
+
+// ─── Recipe 3: Achievements & Stats ─────────────────────────────────────────
+// 数値ハイライト — HTML output
+
+export const teamAchievementsRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-achievements",
+  name: "Achievements & Stats",
+  catalyst: {
+    roleDefinition:
+      "You are a data visualization specialist for landing pages. Generate an achievements/stats section as semantic HTML with inline styles. Display key metrics prominently with large numbers, labels, and subtle animations hints via CSS. If a response language is specified, write all visible text content (labels, descriptions) in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+    temperature: 0.4,
+  },
+  spell: (parts) => {
+    const text = extractText(parts);
+    return `Using the following team data, generate an achievements & stats section as HTML with inline styles. Display key metrics as large, prominent numbers with labels. Use a visually appealing grid layout:
+
+${text}`;
+  },
+  refiner: new TextRefiner(),
+  transforms: [truncateText(6000)],
+};
+
+// ─── Recipe 4: Team Culture & Values ────────────────────────────────────────
+// コアバリュー + 文化紹介 — HTML output
+
+export const teamCultureRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-culture",
+  name: "Team Culture & Values",
+  catalyst: {
+    roleDefinition:
+      "You are a culture branding specialist. Generate a team culture and values section as semantic HTML with inline styles. Present core values with icons (use emoji), descriptions, and a narrative about team culture. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+    temperature: 0.6,
+  },
+  spell: (parts) => [
+    {
+      type: "text",
+      text: "Using the following team culture notes and information, generate a 'Culture & Values' section for a landing page as HTML with inline styles. Include core values with emoji icons, short descriptions, and a narrative paragraph about the team's culture:",
+    },
+    ...parts,
+  ],
+  refiner: new TextRefiner(),
+};
+
+// ─── Recipe 5: Project Showcase ─────────────────────────────────────────────
+// 課題→解決→成果カード — HTML output
+
+export const teamProjectsRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-projects",
+  name: "Project Showcase",
+  catalyst: {
+    roleDefinition:
+      "You are a portfolio designer. Generate a project showcase section as semantic HTML with inline styles. Each project card should follow a Challenge → Solution → Result structure. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+    temperature: 0.5,
+  },
+  spell: (parts) => {
+    const text = extractText(parts);
+    return `Using the following project data, generate a project showcase section as HTML with inline styles. Each project should be displayed as a card with: project name, challenge faced, solution implemented, and measurable results:
+
+${text}`;
+  },
+  refiner: new TextRefiner(),
+  transforms: [truncateText(6000)],
+};
+
+// ─── Recipe 6: Why Join Us? / FAQ ───────────────────────────────────────────
+// 入社理由 + details/summary FAQ — HTML output
+
+export const teamWhyJoinRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-why-join",
+  name: "Why Join Us? / FAQ",
+  catalyst: {
+    roleDefinition:
+      "You are a talent acquisition copywriter. Generate a 'Why Join Us?' section followed by an FAQ accordion as semantic HTML with inline styles. Use <details>/<summary> elements for the FAQ. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
+    temperature: 0.6,
+  },
+  spell: (parts) => [
+    {
+      type: "text",
+      text: "Using the following team information, generate a 'Why Join Us?' section with compelling reasons to join, followed by an FAQ section using HTML <details>/<summary> elements. Style with inline CSS:",
+    },
+    ...parts,
+  ],
+  refiner: new TextRefiner(),
+};
+
+// ─── Recipe 7: Full Page Assembler ──────────────────────────────────────────
+// 全セクション一括生成 — HTML output
+
+export const teamFullPageRecipe: Recipe<MaterialPart[], string> = {
+  id: "team-full-page",
+  name: "Full Page Assembler",
+  catalyst: {
+    roleDefinition:
+      "You are a full-stack landing page designer. Generate a complete, single-page team landing page as semantic HTML with inline styles. Include all major sections: hero, about/mission, team members, achievements, culture & values, project showcase, why join us, and a footer. If a response language is specified, write all visible text content in that language. Output only the HTML — no markdown fences, no explanation.",
+    temperature: 0.6,
+  },
+  spell: (parts) => [
+    {
+      type: "text",
+      text: "Using all the following team materials, generate a complete team landing page as a single HTML document with inline styles. Include these sections in order: Hero (headline + tagline + CTA), About/Mission, Team Members (card grid), Achievements & Stats, Culture & Values, Project Showcase, Why Join Us + FAQ, and Footer. Make it cohesive and visually polished:",
+    },
+    ...parts,
+  ],
+  refiner: new TextRefiner(),
+};
+
+// ─── Recipe Registry ────────────────────────────────────────────────────────
+
+export const teamLpRecipeEntries: RecipeEntry[] = [
+  {
+    recipe: teamHeroRecipe,
+    label: "Hero Section",
+    icon: "\uD83C\uDFAF",
+    description: "Generate a striking hero section with headline, tagline, and CTA",
+    meta: {
+      outputType: "text",
+      transforms: ["imageUrlToBase64()"],
+      promptTemplate:
+        "Generate a hero section HTML with headline, tagline, mission, and CTA ...materials",
+    },
+  },
+  {
+    recipe: teamMembersRecipe,
+    label: "Member Cards",
+    icon: "\uD83D\uDC65",
+    description: "Create a responsive grid of team member profile cards",
+    meta: {
+      outputType: "text",
+      transforms: ["imageUrlToBase64()"],
+      promptTemplate: "Generate member profile cards grid HTML from team profiles ...materials",
+    },
+  },
+  {
+    recipe: teamAchievementsRecipe,
+    label: "Achievements",
+    icon: "\uD83C\uDFC6",
+    description: "Display key metrics and team achievements as visual stats",
+    meta: {
+      outputType: "text",
+      transforms: ["dataToText()", "truncateText(6000)"],
+      promptTemplate: "Generate achievements & stats section HTML from team data ...materials",
+    },
+  },
+  {
+    recipe: teamCultureRecipe,
+    label: "Culture",
+    icon: "\uD83C\uDF31",
+    description: "Showcase team culture, core values, and work philosophy",
+    meta: {
+      outputType: "text",
+      transforms: [],
+      promptTemplate: "Generate culture & values section HTML from team culture notes ...materials",
+    },
+  },
+  {
+    recipe: teamProjectsRecipe,
+    label: "Projects",
+    icon: "\uD83D\uDE80",
+    description: "Showcase projects with challenge, solution, and results",
+    meta: {
+      outputType: "text",
+      transforms: ["dataToText()", "truncateText(6000)"],
+      promptTemplate:
+        "Generate project showcase HTML with challenge/solution/result cards ...materials",
+    },
+  },
+  {
+    recipe: teamWhyJoinRecipe,
+    label: "Why Join",
+    icon: "\uD83E\uDD1D",
+    description: "Create a compelling 'Why Join Us?' section with FAQ accordion",
+    meta: {
+      outputType: "text",
+      transforms: [],
+      promptTemplate:
+        "Generate 'Why Join Us?' section + FAQ accordion HTML from team info ...materials",
+    },
+  },
+  {
+    recipe: teamFullPageRecipe,
+    label: "Full Page",
+    icon: "\uD83D\uDCDC",
+    description: "Assemble a complete team landing page with all sections",
+    meta: {
+      outputType: "text",
+      transforms: ["imageUrlToBase64()", "dataToText()"],
+      promptTemplate: "Generate complete team landing page HTML from all materials ...materials",
+    },
+  },
+];
+
+// biome-ignore lint/suspicious/noExplicitAny: recipe output types vary
+export const teamLpRecipeRegistry: Record<string, Recipe<MaterialPart[], any>> = Object.fromEntries(
+  teamLpRecipeEntries.map((e) => [e.recipe.id, e.recipe]),
+);

--- a/examples/hono-app/team-lp/index.html
+++ b/examples/hono-app/team-lp/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Team LP Generator — チームLP錬金術</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client/team-lp/main.tsx"></script>
+  </body>
+</html>

--- a/examples/hono-app/vite.config.ts
+++ b/examples/hono-app/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
           main: resolve(__dirname, "index.html"),
           common: resolve(__dirname, "common/index.html"),
           travel: resolve(__dirname, "travel/index.html"),
+          "team-lp": resolve(__dirname, "team-lp/index.html"),
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add a new **Team LP Generator** demo that generates team landing page HTML sections from team profiles, goals, culture notes, photos, and data
- 5 catalyst presets (Corporate, Startup, Creative, Minimal, Friendly) with language-aware roleDefinitions
- 7 TextRefiner → HTML recipes: Hero Section, Member Cards, Achievements & Stats, Culture & Values, Project Showcase, Why Join Us / FAQ, Full Page Assembler
- 12 sample materials (3 member profiles, 3 team info texts, 3 photos, 2 data sets, 1 document)
- HTML output rendered via `dangerouslySetInnerHTML` with `<details>` toggle for viewing HTML source
- Language selector support via explicit instructions in both recipe and catalyst roleDefinitions

## Test plan

- [ ] `pnpm -r run build` passes
- [ ] `pnpm -r run typecheck` passes
- [ ] `pnpm -r run lint` passes
- [ ] `pnpm knip` passes
- [ ] Dev server: Hub page shows 3 demo cards (Common, Travel, Team LP)
- [ ] Dev server: `/team-lp/` loads the Team LP Generator UI
- [ ] Recipe selector shows all 7 recipes
- [ ] Catalyst selector shows Default + 5 presets
- [ ] Language dropdown changes output language
- [ ] Compare mode works across multiple catalysts
- [ ] HTML output renders correctly with source view toggle

🤖 Generated with [Claude Code](https://claude.ai/code)