### PR TITLE
🐛 fix: auto-select newly added materials

### DIFF
--- a/examples/hono-app/src/client/playground/App.tsx
+++ b/examples/hono-app/src/client/playground/App.tsx
@@ -326,7 +326,10 @@ export function App() {
           customItems={materialsWithIcons}
           selectedIds={selectedMaterialIds}
           onToggle={toggleMaterial}
-          onAddCustom={store.addMaterial}
+          onAddCustom={(m) => {
+            store.addMaterial(m);
+            setSelectedMaterialIds((prev) => new Set([...prev, m.id]));
+          }}
           onDeleteCustom={handleDeleteMaterial}
         />
       }

--- a/examples/hono-app/src/client/shared/AlchemyDemoApp.tsx
+++ b/examples/hono-app/src/client/shared/AlchemyDemoApp.tsx
@@ -79,6 +79,7 @@ export function AlchemyDemoApp({
 
   const addCustomMaterial = (m: CustomMaterial) => {
     setCustomMaterials((prev) => [...prev, m]);
+    alchemy.toggleMaterial(m.id);
   };
 
   const removeCustomMaterial = (id: string) => {


### PR DESCRIPTION
## Summary
- Playground: newly added materials are now automatically selected (`selectedMaterialIds`) so they are included in the next Transmute call
- Demo pages (Travel, Team LP, etc.): newly added custom materials are auto-selected via `alchemy.toggleMaterial`
- Previously, users had to manually click an added material to select it — without this step, Transmute used stale/empty material sets

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] Add a text material in Playground → verify it appears selected (highlighted border) immediately
- [ ] Click Transmute → verify the new material content is used in the prompt
- [ ] Add a custom material in Travel/Team LP demo → verify auto-selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)