### PR TITLE
✨ feat: sync docs-site version badge with core package.json

### DIFF
--- a/examples/docs-site/index.html
+++ b/examples/docs-site/index.html
@@ -37,7 +37,7 @@
   <main class="landing">
     <!-- Hero -->
     <section class="hero">
-      <span class="badge badge-accent hero-badge">v0.0.0 — Early Preview</span>
+      <span class="badge badge-accent hero-badge">v__ALCHEMY_VERSION__ — Early Preview</span>
       <h1>Transform LLM Interactions with Type Safety</h1>
       <p class="hero-tagline">
         Alchemy is a TypeScript framework for building structured, type-safe LLM pipelines.

--- a/examples/docs-site/vite.config.ts
+++ b/examples/docs-site/vite.config.ts
@@ -1,10 +1,24 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import { changelogPlugin } from "./src/vite-plugin-changelog";
 
+function versionPlugin(): Plugin {
+  const pkg = JSON.parse(
+    readFileSync(resolve(__dirname, "../../packages/core/package.json"), "utf-8"),
+  );
+  return {
+    name: "vite-plugin-version",
+    transformIndexHtml(html) {
+      return html.replaceAll("__ALCHEMY_VERSION__", pkg.version as string);
+    },
+  };
+}
+
 export default defineConfig({
   base: "/alchemy/",
-  plugins: [changelogPlugin()],
+  plugins: [versionPlugin(), changelogPlugin()],
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- Replace hardcoded `v0.0.0` in the landing page hero badge with `__ALCHEMY_VERSION__` placeholder
- Add a small Vite plugin that reads `packages/core/package.json` at build time and replaces the placeholder
- Now displays `v0.1.0` (or whatever the current core version is) automatically

## Test plan
- [x] `pnpm build` in docs-site produces `v0.1.0 — Early Preview` in `dist/index.html`
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)