### PR TITLE
✨ feat: add requiredMaterials to Travel and Team LP recipes

### DIFF
--- a/examples/hono-app/src/team-lp/recipes.ts
+++ b/examples/hono-app/src/team-lp/recipes.ts
@@ -8,6 +8,7 @@ import type { RecipeEntry } from "../shared/recipes.js";
 export const teamHeroRecipe: Recipe<MaterialPart[], string> = {
   id: "team-hero",
   name: "Hero Section",
+  requiredMaterials: [{ type: "text", min: 1, label: "Team info" }],
   catalyst: {
     roleDefinition:
       "You are an expert landing page designer. Generate a compelling hero section as semantic HTML with inline styles. Include a headline, tagline, mission statement, and a call-to-action button. Use modern, responsive CSS. If a response language is specified, write all visible text content (headings, paragraphs, buttons) in that language. Output only the HTML fragment — no markdown fences, no explanation.",
@@ -29,6 +30,7 @@ export const teamHeroRecipe: Recipe<MaterialPart[], string> = {
 export const teamMembersRecipe: Recipe<MaterialPart[], string> = {
   id: "team-members",
   name: "Member Profile Cards",
+  requiredMaterials: [{ type: "text", min: 1, label: "Member profiles" }],
   catalyst: {
     roleDefinition:
       "You are a UI designer specializing in profile cards. Generate a responsive grid of member profile cards as semantic HTML with inline styles. Each card should include the member's name, role, a brief bio, and skills. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
@@ -50,6 +52,7 @@ export const teamMembersRecipe: Recipe<MaterialPart[], string> = {
 export const teamAchievementsRecipe: Recipe<MaterialPart[], string> = {
   id: "team-achievements",
   name: "Achievements & Stats",
+  requiredMaterials: [{ type: "text", min: 1, label: "Team data" }],
   catalyst: {
     roleDefinition:
       "You are a data visualization specialist for landing pages. Generate an achievements/stats section as semantic HTML with inline styles. Display key metrics prominently with large numbers, labels, and subtle animations hints via CSS. If a response language is specified, write all visible text content (labels, descriptions) in that language. Output only the HTML fragment — no markdown fences, no explanation.",
@@ -71,6 +74,7 @@ ${text}`;
 export const teamCultureRecipe: Recipe<MaterialPart[], string> = {
   id: "team-culture",
   name: "Team Culture & Values",
+  requiredMaterials: [{ type: "text", min: 1, label: "Culture notes" }],
   catalyst: {
     roleDefinition:
       "You are a culture branding specialist. Generate a team culture and values section as semantic HTML with inline styles. Present core values with icons (use emoji), descriptions, and a narrative about team culture. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
@@ -92,6 +96,7 @@ export const teamCultureRecipe: Recipe<MaterialPart[], string> = {
 export const teamProjectsRecipe: Recipe<MaterialPart[], string> = {
   id: "team-projects",
   name: "Project Showcase",
+  requiredMaterials: [{ type: "text", min: 1, label: "Project data" }],
   catalyst: {
     roleDefinition:
       "You are a portfolio designer. Generate a project showcase section as semantic HTML with inline styles. Each project card should follow a Challenge → Solution → Result structure. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
@@ -113,6 +118,7 @@ ${text}`;
 export const teamWhyJoinRecipe: Recipe<MaterialPart[], string> = {
   id: "team-why-join",
   name: "Why Join Us? / FAQ",
+  requiredMaterials: [{ type: "text", min: 1, label: "Team info" }],
   catalyst: {
     roleDefinition:
       "You are a talent acquisition copywriter. Generate a 'Why Join Us?' section followed by an FAQ accordion as semantic HTML with inline styles. Use <details>/<summary> elements for the FAQ. If a response language is specified, write all visible text content in that language. Output only the HTML fragment — no markdown fences, no explanation.",
@@ -134,6 +140,7 @@ export const teamWhyJoinRecipe: Recipe<MaterialPart[], string> = {
 export const teamFullPageRecipe: Recipe<MaterialPart[], string> = {
   id: "team-full-page",
   name: "Full Page Assembler",
+  requiredMaterials: [{ type: "text", min: 1, label: "Team materials" }],
   catalyst: {
     roleDefinition:
       "You are a full-stack landing page designer. Generate a complete, single-page team landing page as semantic HTML with inline styles. Include all major sections: hero, about/mission, team members, achievements, culture & values, project showcase, why join us, and a footer. If a response language is specified, write all visible text content in that language. Output only the HTML — no markdown fences, no explanation.",
@@ -160,6 +167,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: ["imageUrlToBase64()"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Team info" }],
       promptTemplate:
         "Generate a hero section HTML with headline, tagline, mission, and CTA ...materials",
     },
@@ -172,6 +180,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: ["imageUrlToBase64()"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Member profiles" }],
       promptTemplate: "Generate member profile cards grid HTML from team profiles ...materials",
     },
   },
@@ -183,6 +192,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: ["dataToText()", "truncateText(6000)"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Team data" }],
       promptTemplate: "Generate achievements & stats section HTML from team data ...materials",
     },
   },
@@ -194,6 +204,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: [],
+      requiredMaterials: [{ type: "text", min: 1, label: "Culture notes" }],
       promptTemplate: "Generate culture & values section HTML from team culture notes ...materials",
     },
   },
@@ -205,6 +216,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: ["dataToText()", "truncateText(6000)"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Project data" }],
       promptTemplate:
         "Generate project showcase HTML with challenge/solution/result cards ...materials",
     },
@@ -217,6 +229,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: [],
+      requiredMaterials: [{ type: "text", min: 1, label: "Team info" }],
       promptTemplate:
         "Generate 'Why Join Us?' section + FAQ accordion HTML from team info ...materials",
     },
@@ -229,6 +242,7 @@ export const teamLpRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: ["imageUrlToBase64()", "dataToText()"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Team materials" }],
       promptTemplate: "Generate complete team landing page HTML from all materials ...materials",
     },
   },

--- a/examples/hono-app/src/travel/recipes.ts
+++ b/examples/hono-app/src/travel/recipes.ts
@@ -10,6 +10,7 @@ import { zodToFieldMeta } from "../shared/zod-helpers.js";
 export const travelMemoryRecipe: Recipe<MaterialPart[], string> = {
   id: "travel-memory",
   name: "Travel Memory Story",
+  requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
   catalyst: {
     roleDefinition:
       "You are a talented travel writer. Transform travel notes, photos, and data into a compelling narrative that brings the journey to life. Write in a warm, vivid style with sensory details. Output in the same language as the input materials.",
@@ -49,6 +50,7 @@ export type TravelHighlights = z.infer<typeof TravelHighlightsSchema>;
 export const travelHighlightsRecipe: Recipe<MaterialPart[], TravelHighlights> = {
   id: "travel-highlights",
   name: "Travel Highlights",
+  requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
   catalyst: {
     roleDefinition:
       "You are a highlights curator. Identify the most memorable and noteworthy moments from travel materials and organize them into a structured highlights reel.",
@@ -78,6 +80,7 @@ ${text}`;
 export const travelBlogRecipe: Recipe<MaterialPart[], string> = {
   id: "travel-blog",
   name: "Travel Blog Post",
+  requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
   catalyst: {
     roleDefinition:
       "You are an experienced travel blogger. Write engaging, SEO-friendly blog posts that balance personal anecdotes with useful information. Include section headers and a conversational tone.",
@@ -113,6 +116,7 @@ export type PhotoCaptions = z.infer<typeof PhotoCaptionsSchema>;
 export const photoCaptionRecipe: Recipe<MaterialPart[], PhotoCaptions> = {
   id: "photo-caption",
   name: "Photo Caption Generator",
+  requiredMaterials: [{ type: "image", min: 1, label: "Travel photos" }],
   catalyst: {
     roleDefinition:
       "You are a creative photo caption specialist. Generate evocative descriptions and social-media-ready captions for travel photos. Capture the mood and story behind each image.",
@@ -151,6 +155,7 @@ export type TripSummary = z.infer<typeof TripSummarySchema>;
 export const tripSummaryRecipe: Recipe<MaterialPart[], TripSummary> = {
   id: "trip-summary",
   name: "Trip Summary Report",
+  requiredMaterials: [{ type: "text", min: 1, label: "Trip notes" }],
   catalyst: {
     roleDefinition:
       "You are a meticulous travel report writer. Compile travel materials into a comprehensive, well-organized trip report with timelines, destinations, and key takeaways.",
@@ -199,6 +204,7 @@ export type BudgetAnalysis = z.infer<typeof BudgetAnalysisSchema>;
 export const budgetAnalysisRecipe: Recipe<MaterialPart[], BudgetAnalysis> = {
   id: "budget-analysis",
   name: "Budget Analysis",
+  requiredMaterials: [{ type: "text", min: 1, label: "Expense data" }],
   catalyst: {
     roleDefinition:
       "You are a travel budget analyst. Analyze travel expense data and provide clear breakdowns, insights, and money-saving tips for future trips.",
@@ -240,6 +246,7 @@ export type DestinationGuide = z.infer<typeof DestinationGuideSchema>;
 export const destinationGuideRecipe: Recipe<MaterialPart[], DestinationGuide> = {
   id: "destination-guide",
   name: "Destination Guide",
+  requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
   catalyst: {
     roleDefinition:
       "You are a knowledgeable travel guide writer. Create practical, insightful destination guides based on travel materials. Include local tips that only experienced travelers would know.",
@@ -275,6 +282,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: [],
+      requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
       promptTemplate:
         "Craft a vivid travel story from notes, photos, data, and documents ...materials",
     },
@@ -288,6 +296,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
       outputType: "json",
       schemaFields: zodToFieldMeta(TravelHighlightsSchema),
       transforms: ["truncateText(4000)"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
       promptTemplate:
         "Extract highlights \u2192 {tripTitle, duration, topMoments[], bestPhoto, oneLiner, recommendations[]}",
     },
@@ -300,6 +309,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
     meta: {
       outputType: "text",
       transforms: [],
+      requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
       promptTemplate:
         "Write a travel blog post with title, sections, observations, and tips ...materials",
     },
@@ -313,6 +323,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
       outputType: "json",
       schemaFields: zodToFieldMeta(PhotoCaptionsSchema),
       transforms: [],
+      requiredMaterials: [{ type: "image", min: 1, label: "Travel photos" }],
       promptTemplate:
         "Generate photo captions \u2192 {captions: [{description, shortCaption, instagramCaption, hashtags[], mood}]}",
     },
@@ -326,6 +337,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
       outputType: "json",
       schemaFields: zodToFieldMeta(TripSummarySchema),
       transforms: ["truncateText(6000)", "dataToText()", "documentToText()"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Trip notes" }],
       promptTemplate:
         "Compile trip report \u2192 {title, overview, destinations[], timeline[], expenses, ratings, lessonsLearned[]}",
     },
@@ -339,6 +351,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
       outputType: "json",
       schemaFields: zodToFieldMeta(BudgetAnalysisSchema),
       transforms: ["dataToText()"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Expense data" }],
       promptTemplate:
         "Analyze expenses \u2192 {summary, totalSpent, dailyAverage, categoryBreakdown[], mostExpensive, savingTips[], comparisonNotes}",
     },
@@ -352,6 +365,7 @@ export const travelRecipeEntries: RecipeEntry[] = [
       outputType: "json",
       schemaFields: zodToFieldMeta(DestinationGuideSchema),
       transforms: ["truncateText(4000)", "documentToText()"],
+      requiredMaterials: [{ type: "text", min: 1, label: "Travel notes" }],
       promptTemplate:
         "Create guide \u2192 {destination, bestSeason, mustSee[], localFood[], transportation[], culturalNotes[], packlist[]}",
     },


### PR DESCRIPTION
## Summary

- Add `requiredMaterials` declarations to all 14 Travel Memory and Team LP recipes
- Travel: text required for 6 recipes, **image** required for Photo Caption
- Team LP: text required for all 7 recipes with descriptive labels (Team info, Member profiles, etc.)

## Changes

| Recipe | Required |
|--------|----------|
| Travel: Memory Story / Highlights / Blog / Trip Report / Guide / Budget | `text` ×1 |
| Travel: Photo Caption | `image` ×1 |
| Team LP: Hero / Members / Achievements / Culture / Projects / Why Join / Full Page | `text` ×1 |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [ ] Manual: select Photo Caption → submit with text only → validation error
- [ ] Manual: select Team Hero → submit without materials → validation error

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)