### PR TITLE
✨ feat: add invalid test materials for validation testing

### DIFF
--- a/examples/hono-app/src/client/team-lp/App.tsx
+++ b/examples/hono-app/src/client/team-lp/App.tsx
@@ -173,6 +173,26 @@ Alchemy Labs is a Series A startup (founded 2022) building the developer platfor
 - Forbes 30 Under 30 — Alice Chen (2024)
 - Best Developer Tool — DevWorld Conference 2024`,
   },
+
+  // ── Invalid Materials (バリデーション確認用) ────────────────────────────────
+  {
+    id: "invalid-image-only",
+    icon: "\u26A0\uFE0F",
+    label: "[Invalid] \u753B\u50CF\u306E\u307F\uFF08\u30C6\u30AD\u30B9\u30C8\u306A\u3057\uFF09",
+    category: "image",
+    text: "",
+    imageUrl: "https://images.unsplash.com/photo-1526481280693-3bfa7568e0f8?w=400",
+  },
+  {
+    id: "invalid-data-only",
+    icon: "\u26A0\uFE0F",
+    label:
+      "[Invalid] \u30C7\u30FC\u30BF\u306E\u307F\uFF08\u30C6\u30AD\u30B9\u30C8\u306A\u3057\uFF09",
+    category: "data",
+    text: "",
+    dataFormat: "csv",
+    dataContent: "col1,col2\na,b",
+  },
 ];
 
 // ─── Category groups for the material shelf ─────────────────────────────────
@@ -181,11 +201,19 @@ const materialGroups: { header: string; filter: (m: MaterialCard) => boolean }[]
   { header: "\uD83D\uDC64 Member Profiles", filter: (m) => m.id.startsWith("member-") },
   {
     header: "\uD83D\uDCDD Team Info",
-    filter: (m) => m.category === "text" && !m.id.startsWith("member-"),
+    filter: (m) =>
+      m.category === "text" && !m.id.startsWith("member-") && !m.id.startsWith("invalid-"),
   },
-  { header: "\uD83D\uDCF7 Photos", filter: (m) => m.category === "image" },
-  { header: "\uD83D\uDCCA Data", filter: (m) => m.category === "data" },
+  {
+    header: "\uD83D\uDCF7 Photos",
+    filter: (m) => m.category === "image" && !m.id.startsWith("invalid-"),
+  },
+  {
+    header: "\uD83D\uDCCA Data",
+    filter: (m) => m.category === "data" && !m.id.startsWith("invalid-"),
+  },
   { header: "\uD83D\uDCC4 Documents", filter: (m) => m.category === "document" },
+  { header: "\u26A0\uFE0F Invalid (test)", filter: (m) => m.id.startsWith("invalid-") },
 ];
 
 // ─── App ────────────────────────────────────────────────────────────────────

--- a/examples/hono-app/src/client/travel/App.tsx
+++ b/examples/hono-app/src/client/travel/App.tsx
@@ -159,17 +159,41 @@ const allMaterials: MaterialCard[] = [
     text: "Short vlog clip from Arashiyama bamboo grove (stub: frame extraction not yet available)",
     videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
   },
+
+  // ── Invalid Materials (バリデーション確認用) ────────────────────────────────
+  {
+    id: "invalid-image-only",
+    icon: "\u26A0\uFE0F",
+    label: "[Invalid] \u753B\u50CF\u306E\u307F\uFF08\u30C6\u30AD\u30B9\u30C8\u306A\u3057\uFF09",
+    category: "image",
+    text: "",
+    imageUrl: "https://images.unsplash.com/photo-1526481280693-3bfa7568e0f8?w=400",
+  },
+  {
+    id: "invalid-empty-text",
+    icon: "\u26A0\uFE0F",
+    label: "[Invalid] \u7A7A\u30C6\u30AD\u30B9\u30C8",
+    category: "text",
+    text: "",
+  },
 ];
 
 // ─── Category groups for the material shelf ─────────────────────────────────
 
 const materialGroups: { header: string; filter: (m: MaterialCard) => boolean }[] = [
-  { header: "\uD83D\uDCDD Texts & Notes", filter: (m) => m.category === "text" },
-  { header: "\uD83D\uDCF7 Photos", filter: (m) => m.category === "image" },
+  {
+    header: "\uD83D\uDCDD Texts & Notes",
+    filter: (m) => m.category === "text" && !m.id.startsWith("invalid-"),
+  },
+  {
+    header: "\uD83D\uDCF7 Photos",
+    filter: (m) => m.category === "image" && !m.id.startsWith("invalid-"),
+  },
   { header: "\uD83D\uDCC4 Documents", filter: (m) => m.category === "document" },
   { header: "\uD83D\uDCCA Data", filter: (m) => m.category === "data" },
   { header: "\uD83C\uDFA7 Audio", filter: (m) => m.category === "audio" },
   { header: "\uD83C\uDFAC Video", filter: (m) => m.category === "video" },
+  { header: "\u26A0\uFE0F Invalid (test)", filter: (m) => m.id.startsWith("invalid-") },
 ];
 
 // ─── App ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add ⚠️ Invalid sample materials to Travel Memory and Team LP apps for verifying material validation works correctly
- Materials are grouped under a separate "⚠️ Invalid (test)" category in the material shelf

## Added Materials

| App | Material | Purpose |
|-----|----------|---------|
| Travel | ⚠️ 画像のみ（テキストなし） | Triggers error on text-required recipes |
| Travel | ⚠️ 空テキスト | Triggers error on text-required recipes |
| Team LP | ⚠️ 画像のみ（テキストなし） | Triggers error on text-required recipes |
| Team LP | ⚠️ データのみ（テキストなし） | Triggers error on text-required recipes |

## Test plan

- [ ] Travel: select only "⚠️ 画像のみ" → pick Memory Story → Transmute → validation error
- [ ] Travel: select only "⚠️ 画像のみ" → pick Photo Caption → Transmute → success (image required)
- [ ] Team LP: select only "⚠️ 画像のみ" → pick Hero Section → Transmute → validation error

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)