### PR TITLE
docs: update documentation for validation, transmuters, and type changes

### DIFF
--- a/examples/docs-site/api/index.html
+++ b/examples/docs-site/api/index.html
@@ -83,7 +83,16 @@
         </table>
 
         <h4 id="namedcatalyst"><code>NamedCatalyst</code></h4>
-        <p>Extends <code>CatalystConfig</code> with a <code>name: string</code> for display purposes (e.g., A/B testing UI).</p>
+        <p>Named catalyst preset for A/B testing UI.</p>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>key</code></td><td><code>string</code></td><td>Unique identifier</td></tr>
+            <tr><td><code>label</code></td><td><code>string</code></td><td>Display name</td></tr>
+            <tr><td><code>config</code></td><td><code>CatalystConfig</code></td><td>Model configuration</td></tr>
+            <tr><td><code>isDefault</code></td><td><code>boolean?</code></td><td>Whether this is the default catalyst</td></tr>
+          </tbody>
+        </table>
 
         <h4 id="materialpart"><code>MaterialPart</code></h4>
         <p>Discriminated union of all material types. Built-in types:</p>
@@ -91,11 +100,11 @@
           <thead><tr><th>Type</th><th>Key Fields</th></tr></thead>
           <tbody>
             <tr><td><code>TextMaterialPart</code></td><td><code>{ type: "text"; text: string }</code></td></tr>
-            <tr><td><code>ImageMaterialPart</code></td><td><code>{ type: "image"; imageUrl: string; imageBase64?: string }</code></td></tr>
-            <tr><td><code>AudioMaterialPart</code></td><td><code>{ type: "audio"; audioUrl: string }</code></td></tr>
-            <tr><td><code>DocumentMaterialPart</code></td><td><code>{ type: "document"; documentText?: string }</code></td></tr>
-            <tr><td><code>VideoMaterialPart</code></td><td><code>{ type: "video"; videoUrl: string }</code></td></tr>
-            <tr><td><code>DataMaterialPart</code></td><td><code>{ type: "data"; dataFormat: "csv"|"json"|"tsv"; dataContent: string }</code></td></tr>
+            <tr><td><code>ImageMaterialPart</code></td><td><code>{ type: "image"; source: { kind: "url"; url } | { kind: "base64"; mediaType; data } }</code></td></tr>
+            <tr><td><code>AudioMaterialPart</code></td><td><code>{ type: "audio"; source: { kind: "url"; url } | { kind: "base64"; mediaType; data } }</code></td></tr>
+            <tr><td><code>DocumentMaterialPart</code></td><td><code>{ type: "document"; source: { kind: "url"; url } | { kind: "text"; text; metadata? } }</code></td></tr>
+            <tr><td><code>VideoMaterialPart</code></td><td><code>{ type: "video"; source: { kind: "url"; url } | { kind: "base64"; mediaType; data } }</code></td></tr>
+            <tr><td><code>DataMaterialPart</code></td><td><code>{ type: "data"; format: "csv"|"json"|"tsv"; content: string; label?: string }</code></td></tr>
           </tbody>
         </table>
 
@@ -149,12 +158,79 @@
         <table class="param-table">
           <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>spell</code></td><td><code>SpellOutput</code></td><td>The prompt instruction</td></tr>
-            <tr><td><code>refiner</code></td><td><code>Refiner&lt;TOutput&gt;?</code></td><td>Output parser/validator</td></tr>
+            <tr><td><code>id</code></td><td><code>string</code></td><td>Unique recipe identifier</td></tr>
+            <tr><td><code>name</code></td><td><code>string?</code></td><td>Display name</td></tr>
+            <tr><td><code>spell</code></td><td><code>(material: TInput) =&gt; SpellOutput | Promise&lt;SpellOutput&gt;</code></td><td>Prompt instruction function</td></tr>
+            <tr><td><code>refiner</code></td><td><code>Refiner&lt;TOutput&gt;</code></td><td>Output parser/validator</td></tr>
             <tr><td><code>catalyst</code></td><td><code>CatalystConfig?</code></td><td>Model configuration</td></tr>
             <tr><td><code>transforms</code></td><td><code>MaterialTransform[]?</code></td><td>Recipe-specific transforms</td></tr>
+            <tr><td><code>requiredMaterials</code></td><td><code>MaterialRequirement[]?</code></td><td>Declarative material type requirements</td></tr>
+            <tr><td><code>validateMaterials</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialValidationResult</code></td><td>Custom validation function</td></tr>
           </tbody>
         </table>
+
+        <hr class="section-divider" />
+
+        <h3 id="core-validation">Validation</h3>
+
+        <h4 id="materialparttype"><code>MaterialPartType</code></h4>
+        <p>Union of all material part type strings: <code>"text" | "image" | "audio" | "document" | "video" | "data"</code></p>
+
+        <h4 id="materialrequirement"><code>MaterialRequirement</code></h4>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>type</code></td><td><code>MaterialPartType</code></td><td>Required material type</td></tr>
+            <tr><td><code>min</code></td><td><code>number?</code></td><td>Minimum count (default: 1)</td></tr>
+            <tr><td><code>max</code></td><td><code>number?</code></td><td>Maximum count (undefined = unlimited)</td></tr>
+            <tr><td><code>label</code></td><td><code>string?</code></td><td>Display label for error messages</td></tr>
+          </tbody>
+        </table>
+
+        <h4 id="materialvalidationresult"><code>MaterialValidationResult</code></h4>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>valid</code></td><td><code>boolean</code></td><td>Whether validation passed</td></tr>
+            <tr><td><code>message</code></td><td><code>string?</code></td><td>Human-readable message</td></tr>
+            <tr><td><code>issues</code></td><td><code>MaterialValidationIssue[]?</code></td><td>Detailed issue list</td></tr>
+          </tbody>
+        </table>
+
+        <h4 id="materialvalidationissue"><code>MaterialValidationIssue</code></h4>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>type</code></td><td><code>MaterialPartType</code></td><td>Material type that failed</td></tr>
+            <tr><td><code>label</code></td><td><code>string?</code></td><td>Label from the requirement</td></tr>
+            <tr><td><code>requirement</code></td><td><code>{ min: number; max?: number }</code></td><td>The requirement that was violated</td></tr>
+            <tr><td><code>actual</code></td><td><code>number</code></td><td>Actual count of this type</td></tr>
+            <tr><td><code>kind</code></td><td><code>"too_few" | "too_many"</code></td><td>Type of violation</td></tr>
+          </tbody>
+        </table>
+
+        <h4 id="validatematerialrequirements"><code>validateMaterialRequirements(requirements, parts)</code></h4>
+        <p>Validate material parts against declarative requirements.</p>
+        <div class="code-block">
+          <div class="code-block-header"><span class="code-block-lang">ts</span></div>
+          <pre><code class="language-ts">function validateMaterialRequirements(
+  requirements: MaterialRequirement[],
+  parts: MaterialPart[],
+): MaterialValidationResult;</code></pre>
+        </div>
+
+        <h4 id="runmaterialvalidation"><code>runMaterialValidation(recipe, parts)</code></h4>
+        <p>Run both declarative (<code>requiredMaterials</code>) and custom (<code>validateMaterials</code>) validation. Declarative check runs first; if it fails, the custom check is skipped.</p>
+        <div class="code-block">
+          <div class="code-block-header"><span class="code-block-lang">ts</span></div>
+          <pre><code class="language-ts">function runMaterialValidation(
+  recipe: {
+    requiredMaterials?: MaterialRequirement[];
+    validateMaterials?: (parts: MaterialPart[]) =&gt; MaterialValidationResult;
+  },
+  parts: MaterialPart[],
+): MaterialValidationResult;</code></pre>
+        </div>
 
         <hr class="section-divider" />
 
@@ -268,6 +344,19 @@ interface AlchemistConfig {
         </table>
         <p>Uses <code>Promise.allSettled</code> internally — all catalysts run in parallel.</p>
 
+        <p><strong><code>generate&lt;TInput, TOutput&gt;(recipe, material, count, options?)</code></strong></p>
+        <p>Generate multiple variations of the same recipe in parallel.</p>
+        <table class="param-table">
+          <thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>recipe</code></td><td><code>Recipe&lt;TInput, TOutput&gt;</code></td><td>The recipe to execute</td></tr>
+            <tr><td><code>material</code></td><td><code>TInput</code></td><td>Input material</td></tr>
+            <tr><td><code>count</code></td><td><code>number</code></td><td>Number of variations to generate</td></tr>
+            <tr><td><code>options</code></td><td><code>TransmutationOptions?</code></td><td>Override options</td></tr>
+          </tbody>
+        </table>
+        <p>Returns: <code>Promise&lt;Record&lt;string, TOutput | { error: Error }&gt;&gt;</code> — Keys are <code>variation-1</code>, <code>variation-2</code>, etc. Uses <code>Promise.allSettled</code> internally.</p>
+
         <hr class="section-divider" />
 
         <h3 id="openaitransmuter"><code>OpenAITransmuter</code></h3>
@@ -290,6 +379,60 @@ interface OpenAITransmuterConfig {
           <tbody>
             <tr><td><code>text</code></td><td>Text content</td></tr>
             <tr><td><code>image</code></td><td>Image URL or base64</td></tr>
+            <tr><td><code>document</code></td><td>Text content or placeholder</td></tr>
+            <tr><td><code>data</code></td><td>Formatted text with label</td></tr>
+            <tr><td><code>audio</code> / <code>video</code></td><td>Placeholder text</td></tr>
+          </tbody>
+        </table>
+
+        <hr class="section-divider" />
+
+        <h3 id="anthropictransmuter"><code>AnthropicTransmuter</code></h3>
+        <p>Anthropic Messages API transmuter.</p>
+
+        <div class="code-block">
+          <div class="code-block-header"><span class="code-block-lang">ts</span></div>
+          <pre><code class="language-ts">new AnthropicTransmuter(config?: AnthropicTransmuterConfig)
+
+interface AnthropicTransmuterConfig {
+  apiKey?: string;       // Defaults to ANTHROPIC_API_KEY env var
+  defaultModel?: string; // Defaults to "claude-sonnet-4-20250514"
+}</code></pre>
+        </div>
+
+        <p>Material type mapping:</p>
+        <table class="param-table">
+          <thead><tr><th>Material Type</th><th>Anthropic Format</th></tr></thead>
+          <tbody>
+            <tr><td><code>text</code></td><td>Text content</td></tr>
+            <tr><td><code>image</code></td><td>Image (base64 or URL)</td></tr>
+            <tr><td><code>document</code></td><td>Text content or placeholder</td></tr>
+            <tr><td><code>data</code></td><td>Formatted text with label</td></tr>
+            <tr><td><code>audio</code> / <code>video</code></td><td>Placeholder text</td></tr>
+          </tbody>
+        </table>
+
+        <hr class="section-divider" />
+
+        <h3 id="googletransmuter"><code>GoogleTransmuter</code></h3>
+        <p>Google Generative AI (Gemini) transmuter.</p>
+
+        <div class="code-block">
+          <div class="code-block-header"><span class="code-block-lang">ts</span></div>
+          <pre><code class="language-ts">new GoogleTransmuter(config?: GoogleTransmuterConfig)
+
+interface GoogleTransmuterConfig {
+  apiKey?: string;       // Defaults to GOOGLE_API_KEY env var
+  defaultModel?: string; // Defaults to "gemini-2.0-flash"
+}</code></pre>
+        </div>
+
+        <p>Material type mapping:</p>
+        <table class="param-table">
+          <thead><tr><th>Material Type</th><th>Google Format</th></tr></thead>
+          <tbody>
+            <tr><td><code>text</code></td><td>Text part</td></tr>
+            <tr><td><code>image</code></td><td>Inline data (base64) or placeholder</td></tr>
             <tr><td><code>document</code></td><td>Text content or placeholder</td></tr>
             <tr><td><code>data</code></td><td>Formatted text with label</td></tr>
             <tr><td><code>audio</code> / <code>video</code></td><td>Placeholder text</td></tr>

--- a/examples/docs-site/concepts/index.html
+++ b/examples/docs-site/concepts/index.html
@@ -57,6 +57,7 @@
         <a href="#transmuter" class="sidebar-link sub">Transmuter</a>
         <a href="#refiner" class="sidebar-link sub">Refiner</a>
         <a href="#recipe" class="sidebar-link sub">Recipe</a>
+        <a href="#material-requirements" class="sidebar-link sub">Material Requirements</a>
         <a href="#alchemist" class="sidebar-link sub">Alchemist</a>
       </div>
     </aside>
@@ -96,11 +97,11 @@
           </thead>
           <tbody>
             <tr><td><code>text</code></td><td>Plain text content</td><td><code>text</code></td></tr>
-            <tr><td><code>image</code></td><td>Image via URL or base64</td><td><code>imageUrl</code></td></tr>
-            <tr><td><code>audio</code></td><td>Audio content</td><td><code>audioUrl</code></td></tr>
-            <tr><td><code>document</code></td><td>Document text</td><td><code>documentText</code></td></tr>
-            <tr><td><code>video</code></td><td>Video content</td><td><code>videoUrl</code></td></tr>
-            <tr><td><code>data</code></td><td>Structured data (CSV, JSON, TSV)</td><td><code>dataFormat</code>, <code>dataContent</code></td></tr>
+            <tr><td><code>image</code></td><td>Image via URL or base64</td><td><code>source: { kind: "url" | "base64" }</code></td></tr>
+            <tr><td><code>audio</code></td><td>Audio content</td><td><code>source: { kind: "url" | "base64" }</code></td></tr>
+            <tr><td><code>document</code></td><td>Document text or URL</td><td><code>source: { kind: "url" | "text" }</code></td></tr>
+            <tr><td><code>video</code></td><td>Video content</td><td><code>source: { kind: "url" | "base64" }</code></td></tr>
+            <tr><td><code>data</code></td><td>Structured data (CSV, JSON, TSV)</td><td><code>format</code>, <code>content</code>, <code>label?</code></td></tr>
           </tbody>
         </table>
 
@@ -111,8 +112,8 @@
           <pre><code class="language-ts">// Multiple material types in a single request
 const materials = [
   { type: "text", text: "Analyze this chart and data" },
-  { type: "image", imageUrl: "https://example.com/chart.png" },
-  { type: "data", dataFormat: "csv", dataContent: "name,value\nA,10\nB,20" },
+  { type: "image", source: { kind: "url", url: "https://example.com/chart.png" } },
+  { type: "data", format: "csv", content: "name,value\nA,10\nB,20" },
 ];</code></pre>
         </div>
 
@@ -277,6 +278,37 @@ const summarizeRecipe: Recipe&lt;string, { summary: string; bullets: string[] }&
         </div>
 
         <p>Recipes are generic over <code>TInput</code> and <code>TOutput</code>, giving you end-to-end type safety from input to output.</p>
+
+        <h3 id="material-requirements">Material Requirements</h3>
+        <p>Recipes can declare what types of materials they expect using <code>requiredMaterials</code>. This enables validation before transmutation, preventing wasted API calls on invalid input.</p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">ts</span>
+          </div>
+          <pre><code class="language-ts">const imageAnalysisRecipe: Recipe&lt;MaterialPart[], AnalysisResult&gt; = {
+  id: "image-analysis",
+  spell: (material) =&gt; ({ output: "Analyze the provided images" }),
+  refiner: new JsonRefiner(AnalysisSchema),
+  // Declarative: require 1-5 images
+  requiredMaterials: [
+    { type: "image", min: 1, max: 5, label: "Analysis images" },
+  ],
+  // Custom: ensure at least one text description is included
+  validateMaterials: (parts) =&gt; {
+    const hasText = parts.some((p) =&gt; p.type === "text");
+    return hasText
+      ? { valid: true }
+      : { valid: false, message: "Please include a text description" };
+  },
+};</code></pre>
+        </div>
+
+        <p>Validation runs in two stages via <code>runMaterialValidation()</code>:</p>
+        <ol>
+          <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type</li>
+          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> only if the declarative check passes</li>
+        </ol>
 
         <h2 id="alchemist">Alchemist</h2>
         <p>The Alchemist is the main orchestrator. It wires everything together and executes the transmutation pipeline:</p>

--- a/examples/docs-site/examples/index.html
+++ b/examples/docs-site/examples/index.html
@@ -55,6 +55,7 @@
         <a href="#streaming" class="sidebar-link sub">Streaming</a>
         <a href="#compare" class="sidebar-link sub">A/B Comparison</a>
         <a href="#react-ui" class="sidebar-link sub">React UI</a>
+        <a href="#validation" class="sidebar-link sub">Validation</a>
       </div>
     </aside>
 
@@ -180,12 +181,12 @@ const result = await alchemist.transmute({
   },
   materials: [
     { type: "text", text: "Q4 2024 Sales Report" },
-    { type: "image", imageUrl: "https://example.com/sales-chart.png" },
+    { type: "image", source: { kind: "url", url: "https://example.com/sales-chart.png" } },
     {
       type: "data",
-      dataFormat: "csv",
-      dataContent: "month,revenue\nOct,45000\nNov,52000\nDec,61000",
-      dataLabel: "Monthly Revenue",
+      format: "csv",
+      content: "month,revenue\nOct,45000\nNov,52000\nDec,61000",
+      label: "Monthly Revenue",
     },
   ],
 });
@@ -357,6 +358,74 @@ function TranslatorApp() {
         <div class="callout callout-tip">
           <strong>Live Demo</strong>
           <p>Check out the <a href="https://github.com/EdV4H/alchemy/tree/main/examples/hono-app" target="_blank" rel="noopener">hono-app example</a> for a full-stack demo with React frontend and Hono backend, including a playground, travel assistant, and team landing page generator.</p>
+        </div>
+
+        <!-- Example 7 -->
+        <h2 id="validation">Material Validation</h2>
+        <p>Validate materials before transmutation to catch errors early and avoid wasted API calls.</p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">ts</span>
+          </div>
+          <pre><code class="language-ts">import { JsonRefiner, runMaterialValidation } from "@edv4h/alchemy-core";
+import type { Recipe, MaterialPart } from "@edv4h/alchemy-core";
+import { z } from "zod";
+
+// Define a recipe with material requirements
+const imageAnalysisRecipe: Recipe&lt;MaterialPart[], { description: string }&gt; = {
+  id: "image-analysis",
+  spell: (material) =&gt; ({ output: "Describe the provided images" }),
+  refiner: new JsonRefiner(z.object({ description: z.string() })),
+  // Declarative: require 1-3 images
+  requiredMaterials: [
+    { type: "image", min: 1, max: 3, label: "Photos to analyze" },
+  ],
+};
+
+// Validate before calling the API
+const materials: MaterialPart[] = [
+  { type: "text", text: "What's in this photo?" },
+];
+
+const validation = runMaterialValidation(imageAnalysisRecipe, materials);
+
+if (!validation.valid) {
+  console.error("Validation failed:");
+  for (const issue of validation.issues ?? []) {
+    console.error(
+      `  ${issue.label ?? issue.type}: expected ${issue.requirement.min}–${issue.requirement.max ?? "∞"}, got ${issue.actual} (${issue.kind})`
+    );
+  }
+  // → "Photos to analyze: expected 1–3, got 0 (too_few)"
+}</code></pre>
+        </div>
+
+        <h3>Custom Validation</h3>
+        <p>For more complex rules, use <code>validateMaterials</code> alongside or instead of <code>requiredMaterials</code>.</p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">ts</span>
+          </div>
+          <pre><code class="language-ts">const recipe: Recipe&lt;MaterialPart[], string&gt; = {
+  id: "travel-plan",
+  spell: (material) =&gt; ({ output: "Create a travel itinerary" }),
+  refiner: new TextRefiner(),
+  requiredMaterials: [
+    { type: "text", min: 1, label: "Travel preferences" },
+  ],
+  validateMaterials: (parts) =&gt; {
+    const textParts = parts.filter((p) =&gt; p.type === "text");
+    const totalLength = textParts.reduce(
+      (sum, p) =&gt; sum + (p.type === "text" ? p.text.length : 0), 0,
+    );
+    if (totalLength &lt; 20) {
+      return { valid: false, message: "Please provide more detail (at least 20 characters)" };
+    }
+    return { valid: true };
+  },
+};</code></pre>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- **API Reference**: Updated `MaterialPart` types to new `source`-based format, fixed `NamedCatalyst` and `Recipe` type definitions, added Validation section (types + helper functions), `generate()` method, `AnthropicTransmuter`, and `GoogleTransmuter`
- **Concepts**: Updated Material table and code examples to new format, added Material Requirements subsection under Recipe
- **Examples**: Updated multimodal code example to new format, added Material Validation example with declarative and custom validation patterns

## Test plan
- [x] `pnpm build` passes (all 5 packages)
- [ ] Verify all pages render correctly in local dev server (`cd examples/docs-site && pnpm dev`)
- [ ] Check all anchor links work (sidebar navigation)
- [ ] Verify code block syntax highlighting renders properly

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)