### PR TITLE
Phase 3: peerDependencies化 + docs-site修正 + README整備

### DIFF
--- a/.changeset/peer-dependencies-docs-readme.md
+++ b/.changeset/peer-dependencies-docs-readme.md
@@ -1,0 +1,8 @@
+---
+"@edv4h/alchemy-plugin-transmuter-openai": minor
+"@edv4h/alchemy-plugin-transmuter-anthropic": minor
+"@edv4h/alchemy-plugin-transmuter-google": minor
+"@edv4h/alchemy-node": patch
+---
+
+Move LLM SDK dependencies to peerDependencies in transmuter plugins, update alchemy-node description, fix docs-site import paths, and add README files for all packages

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Alchemy
+
+Type-safe LLM orchestration framework for TypeScript.
+
+Define recipes, transform multimodal inputs, and get validated outputs — all with full type inference.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@edv4h/alchemy-core`](./packages/core) | Type definitions, Refiners, Material utilities, and Transform helpers |
+| [`@edv4h/alchemy-node`](./packages/node) | Alchemist orchestrator class with core re-exports |
+| [`@edv4h/alchemy-react`](./packages/react) | React hooks for LLM-powered UIs |
+| [`@edv4h/alchemy-plugin-transmuter-openai`](./packages/plugin-transmuter-openai) | OpenAI transmuter plugin |
+| [`@edv4h/alchemy-plugin-transmuter-anthropic`](./packages/plugin-transmuter-anthropic) | Anthropic transmuter plugin |
+| [`@edv4h/alchemy-plugin-transmuter-google`](./packages/plugin-transmuter-google) | Google Gemini transmuter plugin |
+| [`@edv4h/alchemy-plugin-transforms-node`](./packages/plugin-transforms-node) | Node.js-specific material transforms |
+
+## Quick Start
+
+```bash
+pnpm add @edv4h/alchemy-core @edv4h/alchemy-node @edv4h/alchemy-plugin-transmuter-openai zod
+```
+
+```ts
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
+import { JsonRefiner } from "@edv4h/alchemy-core";
+import { z } from "zod";
+
+const alchemist = new Alchemist({
+  transmuter: new OpenAITransmuter({ apiKey: process.env.OPENAI_API_KEY }),
+});
+
+const result = await alchemist.transmute({
+  recipe: {
+    spell: { output: "Summarize this text in 3 bullet points" },
+    refiner: new JsonRefiner(z.object({
+      bullets: z.array(z.string()).length(3),
+    })),
+  },
+  materials: [{ type: "text", text: "Your long document here..." }],
+});
+
+console.log(result.output.bullets);
+// → ["Point 1", "Point 2", "Point 3"]  ✓ Fully typed!
+```
+
+## Architecture
+
+Every request flows through a composable pipeline:
+
+```
+Material → Transform → Spell → Transmuter → Refiner → Typed Output
+```
+
+- **Material** — Multimodal inputs (text, image, audio, video, document, data)
+- **Transform** — Preprocessing functions that modify materials
+- **Spell** — The prompt / instruction
+- **Transmuter** — LLM provider adapter (OpenAI, Anthropic, Google)
+- **Refiner** — Output parser and validator (Text, JSON/Zod, Mermaid)
+- **Recipe** — A reusable formula combining spell, refiner, catalyst, and transforms
+
+## Development
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+pnpm lint
+```
+
+## License
+
+MIT

--- a/examples/docs-site/concepts/index.html
+++ b/examples/docs-site/concepts/index.html
@@ -132,6 +132,7 @@ const materials = [
   filterByType,
   dataToText,
 } from "@edv4h/alchemy-core";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 // Built-in transforms
 const alchemist = new Alchemist({
@@ -143,7 +144,7 @@ const alchemist = new Alchemist({
 });</code></pre>
         </div>
 
-        <p><strong>Node.js-specific transforms</strong> are also available:</p>
+        <p><strong>Node.js-specific transforms</strong> are available in <code>@edv4h/alchemy-plugin-transforms-node</code>:</p>
         <ul>
           <li><code>imageUrlToBase64()</code> — Fetches remote images and converts to base64</li>
           <li><code>documentToText()</code> — Extracts text from documents</li>
@@ -217,7 +218,7 @@ const catalysts: Record&lt;string, NamedCatalyst&gt; = {
 }</code></pre>
         </div>
 
-        <p>Alchemy ships with <code>OpenAITransmuter</code> for the OpenAI Chat Completions API. You can implement custom transmuters for any LLM provider (Anthropic, Google, local models, etc.).</p>
+        <p>Alchemy provides transmuter plugins for popular LLM providers: <code>@edv4h/alchemy-plugin-transmuter-openai</code>, <code>@edv4h/alchemy-plugin-transmuter-anthropic</code>, and <code>@edv4h/alchemy-plugin-transmuter-google</code>. You can also implement custom transmuters for any provider.</p>
 
         <div class="callout callout-tip">
           <strong>Custom Transmuter</strong>
@@ -317,7 +318,8 @@ const summarizeRecipe: Recipe&lt;string, { summary: string; bullets: string[] }&
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+          <pre><code class="language-ts">import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 const alchemist = new Alchemist({
   transmuter: new OpenAITransmuter({ apiKey: "..." }),

--- a/examples/docs-site/examples/index.html
+++ b/examples/docs-site/examples/index.html
@@ -79,7 +79,8 @@
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+          <pre><code class="language-ts">import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 const alchemist = new Alchemist({
   transmuter: new OpenAITransmuter({
@@ -113,7 +114,8 @@ console.log(result.output);
             <span class="code-block-lang">ts</span>
           </div>
           <pre><code class="language-ts">import { JsonRefiner } from "@edv4h/alchemy-core";
-import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 import { z } from "zod";
 
 const ProductSchema = z.object({
@@ -156,7 +158,9 @@ console.log(result.output.features[0]); // { title: "...", description: "..." }<
             <span class="code-block-lang">ts</span>
           </div>
           <pre><code class="language-ts">import { JsonRefiner, dataToText } from "@edv4h/alchemy-core";
-import { Alchemist, OpenAITransmuter, imageUrlToBase64 } from "@edv4h/alchemy-node";
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
+import { imageUrlToBase64 } from "@edv4h/alchemy-plugin-transforms-node";
 import { z } from "zod";
 
 const alchemist = new Alchemist({
@@ -203,7 +207,8 @@ console.log(result.output.insights);  // ["Revenue grew 35% over Q4", ...]</code
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+          <pre><code class="language-ts">import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 const alchemist = new Alchemist({
   transmuter: new OpenAITransmuter(),
@@ -245,7 +250,8 @@ console.log(`\n\nTotal length: ${fullText.length} characters`);</code></pre>
             <span class="code-block-lang">ts</span>
           </div>
           <pre><code class="language-ts">import { JsonRefiner } from "@edv4h/alchemy-core";
-import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 import { z } from "zod";
 
 const CopySchema = z.object({

--- a/examples/docs-site/getting-started/index.html
+++ b/examples/docs-site/getting-started/index.html
@@ -74,7 +74,13 @@
           <div class="code-block-header">
             <span class="code-block-lang">bash</span>
           </div>
-          <pre><code class="language-bash">pnpm add @edv4h/alchemy-core @edv4h/alchemy-node</code></pre>
+          <pre><code class="language-bash"># Core + Node runtime
+pnpm add @edv4h/alchemy-core @edv4h/alchemy-node
+
+# Add a transmuter plugin for your LLM provider
+pnpm add @edv4h/alchemy-plugin-transmuter-openai    # OpenAI
+# pnpm add @edv4h/alchemy-plugin-transmuter-anthropic  # Anthropic
+# pnpm add @edv4h/alchemy-plugin-transmuter-google     # Google Gemini</code></pre>
         </div>
 
         <p>If you plan to use structured output with JSON schemas, also install Zod:</p>
@@ -98,7 +104,8 @@
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+          <pre><code class="language-ts">import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 // 1. Create an Alchemist with an OpenAI transmuter
 const alchemist = new Alchemist({

--- a/examples/docs-site/index.html
+++ b/examples/docs-site/index.html
@@ -52,7 +52,8 @@
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import { Alchemist, OpenAITransmuter } from "@edv4h/alchemy-node";
+          <pre><code class="language-ts">import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 import { JsonRefiner } from "@edv4h/alchemy-core";
 import { z } from "zod";
 
@@ -112,12 +113,32 @@ console.log(result.output.bullets);
         <div class="card package-card">
           <span class="badge badge-accent">node</span>
           <h3 class="card-title">@edv4h/alchemy-node</h3>
-          <p class="card-desc">The Alchemist orchestrator class, OpenAI Transmuter, and Node-specific transforms (image-to-base64, document-to-text).</p>
+          <p class="card-desc">The Alchemist orchestrator class with core re-exports. Provides the main entry point for Node.js server-side usage.</p>
         </div>
         <div class="card package-card">
           <span class="badge badge-accent">react</span>
           <h3 class="card-title">@edv4h/alchemy-react</h3>
           <p class="card-desc">React hooks — useAlchemy, useTransmute, useCompare — for building interactive LLM-powered UIs with full state management.</p>
+        </div>
+        <div class="card package-card">
+          <span class="badge badge-accent">plugin</span>
+          <h3 class="card-title">@edv4h/alchemy-plugin-transmuter-openai</h3>
+          <p class="card-desc">OpenAI transmuter plugin — connects Alchemy to GPT-4o, GPT-4o-mini and other OpenAI models.</p>
+        </div>
+        <div class="card package-card">
+          <span class="badge badge-accent">plugin</span>
+          <h3 class="card-title">@edv4h/alchemy-plugin-transmuter-anthropic</h3>
+          <p class="card-desc">Anthropic transmuter plugin — connects Alchemy to Claude models via the Anthropic SDK.</p>
+        </div>
+        <div class="card package-card">
+          <span class="badge badge-accent">plugin</span>
+          <h3 class="card-title">@edv4h/alchemy-plugin-transmuter-google</h3>
+          <p class="card-desc">Google transmuter plugin — connects Alchemy to Gemini models via the Google Generative AI SDK.</p>
+        </div>
+        <div class="card package-card">
+          <span class="badge badge-accent">plugin</span>
+          <h3 class="card-title">@edv4h/alchemy-plugin-transforms-node</h3>
+          <p class="card-desc">Node.js transform helpers — imageUrlToBase64, documentToText, and other server-side material transforms.</p>
         </div>
       </div>
     </section>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,33 @@
+# @edv4h/alchemy-core
+
+Core library for the Alchemy framework — type definitions, Refiners, Material utilities, and Transform helpers.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-core
+```
+
+## What's Included
+
+- **Refiners** — `TextRefiner`, `JsonRefiner`, `MermaidRefiner`
+- **Transforms** — `truncateText`, `prependText`, `filterByType`, `dataToText`
+- **Material utilities** — `extractText`, `extractAllText`, `isTextOnly`, `toMaterialParts`
+- **Validation** — `runMaterialValidation`, `validateMaterialRequirements`
+- **Types** — `MaterialPart`, `Recipe`, `Transmuter`, `CatalystConfig`, `Refiner`, etc.
+
+## Usage
+
+```ts
+import { JsonRefiner, truncateText } from "@edv4h/alchemy-core";
+import { z } from "zod";
+
+const refiner = new JsonRefiner(z.object({
+  summary: z.string(),
+  tags: z.array(z.string()),
+}));
+```
+
+## License
+
+MIT

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,47 @@
+# @edv4h/alchemy-node
+
+Node.js runtime for the Alchemy framework — the Alchemist orchestrator class with core re-exports.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-core @edv4h/alchemy-node
+```
+
+You also need a transmuter plugin for your LLM provider:
+
+```bash
+pnpm add @edv4h/alchemy-plugin-transmuter-openai    # OpenAI
+# pnpm add @edv4h/alchemy-plugin-transmuter-anthropic  # Anthropic
+# pnpm add @edv4h/alchemy-plugin-transmuter-google     # Google Gemini
+```
+
+## Usage
+
+```ts
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
+
+const alchemist = new Alchemist({
+  transmuter: new OpenAITransmuter({ apiKey: process.env.OPENAI_API_KEY }),
+});
+
+const result = await alchemist.transmute({
+  recipe: {
+    spell: { output: "Translate this to French" },
+  },
+  materials: [{ type: "text", text: "Hello, world!" }],
+});
+
+console.log(result.output);
+// → "Bonjour, le monde !"
+```
+
+## What's Included
+
+- **Alchemist** — Main orchestrator with `transmute()`, `stream()`, `compare()`, and `generate()`
+- All `@edv4h/alchemy-core` exports are re-exported for convenience
+
+## License
+
+MIT

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edv4h/alchemy-node",
   "version": "0.1.0",
-  "description": "Node.js runtime for Alchemy — LLM transmuters for OpenAI, Anthropic, and Google",
+  "description": "Node.js runtime for Alchemy — the Alchemist orchestrator class with core re-exports",
   "license": "MIT",
   "author": "EdV4H",
   "repository": {

--- a/packages/plugin-transforms-node/README.md
+++ b/packages/plugin-transforms-node/README.md
@@ -1,0 +1,36 @@
+# @edv4h/alchemy-plugin-transforms-node
+
+Node.js-specific material transforms for the Alchemy framework — image conversion, document extraction, and more.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-plugin-transforms-node
+```
+
+## Usage
+
+```ts
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
+import { imageUrlToBase64, documentToText } from "@edv4h/alchemy-plugin-transforms-node";
+
+const alchemist = new Alchemist({
+  transmuter: new OpenAITransmuter(),
+  transforms: [
+    imageUrlToBase64(),  // Convert image URLs to base64 for API
+    documentToText(),    // Extract text from documents
+  ],
+});
+```
+
+## Transforms
+
+- **`imageUrlToBase64()`** — Fetches remote images and converts to base64
+- **`documentToText()`** — Extracts text from document parts
+- **`audioToText()`** — Audio transcription (stub support)
+- **`videoToFrames()`** — Video frame extraction (stub support)
+
+## License
+
+MIT

--- a/packages/plugin-transmuter-anthropic/README.md
+++ b/packages/plugin-transmuter-anthropic/README.md
@@ -1,0 +1,37 @@
+# @edv4h/alchemy-plugin-transmuter-anthropic
+
+Anthropic (Claude) transmuter plugin for the Alchemy framework — connects to Claude models via the Anthropic SDK.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-plugin-transmuter-anthropic @anthropic-ai/sdk
+```
+
+**Peer dependency:** `@anthropic-ai/sdk@^0.39.0`
+
+## Usage
+
+```ts
+import { Alchemist } from "@edv4h/alchemy-node";
+import { AnthropicTransmuter } from "@edv4h/alchemy-plugin-transmuter-anthropic";
+
+const alchemist = new Alchemist({
+  transmuter: new AnthropicTransmuter({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+  }),
+});
+```
+
+## Configuration
+
+```ts
+interface AnthropicTransmuterConfig {
+  apiKey?: string;       // defaults to ANTHROPIC_API_KEY env var
+  defaultModel?: string; // defaults to "claude-sonnet-4-20250514"
+}
+```
+
+## License
+
+MIT

--- a/packages/plugin-transmuter-anthropic/package.json
+++ b/packages/plugin-transmuter-anthropic/package.json
@@ -45,10 +45,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@edv4h/alchemy-core": "workspace:*",
+    "@edv4h/alchemy-core": "workspace:*"
+  },
+  "peerDependencies": {
     "@anthropic-ai/sdk": "^0.39.0"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/plugin-transmuter-google/README.md
+++ b/packages/plugin-transmuter-google/README.md
@@ -1,0 +1,37 @@
+# @edv4h/alchemy-plugin-transmuter-google
+
+Google (Gemini) transmuter plugin for the Alchemy framework — connects to Gemini models via the Google Generative AI SDK.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-plugin-transmuter-google @google/generative-ai
+```
+
+**Peer dependency:** `@google/generative-ai@^0.24.0`
+
+## Usage
+
+```ts
+import { Alchemist } from "@edv4h/alchemy-node";
+import { GoogleTransmuter } from "@edv4h/alchemy-plugin-transmuter-google";
+
+const alchemist = new Alchemist({
+  transmuter: new GoogleTransmuter({
+    apiKey: process.env.GOOGLE_API_KEY,
+  }),
+});
+```
+
+## Configuration
+
+```ts
+interface GoogleTransmuterConfig {
+  apiKey?: string;       // defaults to GOOGLE_API_KEY env var
+  defaultModel?: string; // defaults to "gemini-1.5-flash"
+}
+```
+
+## License
+
+MIT

--- a/packages/plugin-transmuter-google/package.json
+++ b/packages/plugin-transmuter-google/package.json
@@ -45,10 +45,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@edv4h/alchemy-core": "workspace:*",
+    "@edv4h/alchemy-core": "workspace:*"
+  },
+  "peerDependencies": {
     "@google/generative-ai": "^0.24.0"
   },
   "devDependencies": {
+    "@google/generative-ai": "^0.24.0",
     "@types/node": "^25.3.0",
     "typescript": "^5.7.0"
   }

--- a/packages/plugin-transmuter-openai/README.md
+++ b/packages/plugin-transmuter-openai/README.md
@@ -1,0 +1,39 @@
+# @edv4h/alchemy-plugin-transmuter-openai
+
+OpenAI transmuter plugin for the Alchemy framework — connects to GPT-4o, GPT-4o-mini, and other OpenAI models.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-plugin-transmuter-openai openai
+```
+
+**Peer dependency:** `openai@^4.100.0`
+
+## Usage
+
+```ts
+import { Alchemist } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
+
+const alchemist = new Alchemist({
+  transmuter: new OpenAITransmuter({
+    apiKey: process.env.OPENAI_API_KEY,
+    defaultModel: "gpt-4o",
+  }),
+});
+```
+
+## Configuration
+
+```ts
+interface OpenAITransmuterConfig {
+  apiKey?: string;       // defaults to OPENAI_API_KEY env var
+  defaultModel?: string; // defaults to "gpt-4o-mini"
+  baseURL?: string;      // custom API endpoint
+}
+```
+
+## License
+
+MIT

--- a/packages/plugin-transmuter-openai/package.json
+++ b/packages/plugin-transmuter-openai/package.json
@@ -45,10 +45,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@edv4h/alchemy-core": "workspace:*",
+    "@edv4h/alchemy-core": "workspace:*"
+  },
+  "peerDependencies": {
     "openai": "^4.100.0"
   },
   "devDependencies": {
+    "openai": "^4.100.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,45 @@
+# @edv4h/alchemy-react
+
+React hooks for the Alchemy framework — headless UI primitives for LLM-powered components.
+
+## Install
+
+```bash
+pnpm add @edv4h/alchemy-react
+```
+
+**Peer dependency:** `react@^18.0.0 || ^19.0.0`
+
+## Usage
+
+```tsx
+import { useAlchemy } from "@edv4h/alchemy-react";
+
+function TranslatorApp() {
+  const { transmute, result, isLoading, error } = useAlchemy<{ translation: string }>({
+    initialRecipeId: "translate",
+    baseUrl: "/api",
+  });
+
+  return (
+    <div>
+      <button onClick={() => transmute([{ type: "text", text: "Hello" }])}>
+        Translate
+      </button>
+      {isLoading && <p>Loading...</p>}
+      {result && <p>{result.translation}</p>}
+    </div>
+  );
+}
+```
+
+## Hooks
+
+- **`useAlchemy`** — Full-featured hook with recipe selection, catalyst switching, and state management
+- **`useTransmute`** — Simplified hook for single transmutation
+- **`useCompare`** — A/B comparison across multiple catalysts
+- **`useGenerate`** — Generate multiple variations in parallel
+
+## License
+
+MIT

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,13 +157,13 @@ importers:
 
   packages/plugin-transmuter-anthropic:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.39.0
-        version: 0.39.0
       '@edv4h/alchemy-core':
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.39.0
+        version: 0.39.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -173,10 +173,10 @@ importers:
       '@edv4h/alchemy-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
       '@google/generative-ai':
         specifier: ^0.24.0
         version: 0.24.1
-    devDependencies:
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
@@ -189,10 +189,10 @@ importers:
       '@edv4h/alchemy-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
       openai:
         specifier: ^4.100.0
         version: 4.104.0(ws@8.19.0)(zod@3.25.76)
-    devDependencies:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Move LLM SDK dependencies (`openai`, `@anthropic-ai/sdk`, `@google/generative-ai`) from `dependencies` to `peerDependencies` + `devDependencies` in transmuter plugin packages, matching the pattern used by `alchemy-react`
- Update `alchemy-node` package description to reflect that transmuters have been extracted
- Fix all docs-site code examples to import from new plugin package paths instead of `@edv4h/alchemy-node`
- Add 4 plugin packages to the docs-site packages listing
- Add README.md to root and all 7 packages

## Test plan

- [x] `pnpm install` — no resolution errors
- [x] `pnpm build` — all 9 packages build successfully
- [x] `pnpm test` — 88 tests pass
- [x] `pnpm typecheck` — all 14 packages pass
- [x] `pnpm lint` — no issues
- [x] docs-site builds (`vite build`) without errors

🤖 Generated with [Claude Code](https://claude.ai/code)