### PR TITLE
✨ feat: 素材評価システム（evaluate / judgeMaterials）

### DIFF
--- a/.changeset/material-evaluation-system.md
+++ b/.changeset/material-evaluation-system.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/alchemy-core": minor
+"@edv4h/alchemy-node": minor
+---
+
+Add material evaluation system for graded quality scoring
+
+- New types: `MaterialEvaluation`, `MaterialEvaluationEntry`, `MaterialJudgement`
+- `MaterialRequirement.evaluate` — per-material quality scoring (0-1)
+- `Recipe.judgeMaterials` — aggregate evaluation to determine transmute eligibility
+- `MaterialValidationResult` extended with `evaluations` and `judgement`
+- `MaterialValidationError` error class with full result details
+- `AlchemistConfig.validateMaterials` — auto-validate in transmute()/stream()
+- **Breaking**: `runMaterialValidation` is now async (returns `Promise<MaterialValidationResult>`)

--- a/examples/hono-app/src/client/shared/AlchemyDemoApp.tsx
+++ b/examples/hono-app/src/client/shared/AlchemyDemoApp.tsx
@@ -126,14 +126,14 @@ export function AlchemyDemoApp({
     });
   }, [selectedMaterials]);
 
-  const validateBeforeSubmit = useCallback((): boolean => {
+  const validateBeforeSubmit = useCallback(async (): Promise<boolean> => {
     if (!selectedEntry) return true;
     const recipe = selectedEntry.recipe;
     if (!recipe.requiredMaterials && !recipe.validateMaterials) return true;
 
     const inputs = buildMaterialInputs();
     const parts = toMaterialParts(inputs) as MaterialPart[];
-    const result = runMaterialValidation(recipe, parts);
+    const result = await runMaterialValidation(recipe, parts);
     if (!result.valid) {
       const msg =
         result.message ??
@@ -153,14 +153,14 @@ export function AlchemyDemoApp({
     return true;
   }, [selectedEntry, buildMaterialInputs]);
 
-  const handleTransmute = useCallback(() => {
-    if (!validateBeforeSubmit()) return;
+  const handleTransmute = useCallback(async () => {
+    if (!(await validateBeforeSubmit())) return;
     setLocalError(null);
     alchemy.transmute(buildMaterialInputs());
   }, [alchemy.transmute, buildMaterialInputs, validateBeforeSubmit]);
 
-  const handleGenerate = useCallback(() => {
-    if (!validateBeforeSubmit()) return;
+  const handleGenerate = useCallback(async () => {
+    if (!(await validateBeforeSubmit())) return;
     setLocalError(null);
     alchemy.generate(buildMaterialInputs());
   }, [alchemy.generate, buildMaterialInputs, validateBeforeSubmit]);

--- a/examples/hono-app/src/server/index.ts
+++ b/examples/hono-app/src/server/index.ts
@@ -181,7 +181,7 @@ app.post("/api/transmute/:recipeId", async (c) => {
     const alchemist = resolveAlchemist(c);
     const parts = serverToMaterialParts(materials);
 
-    const validation = runMaterialValidation(recipe, parts);
+    const validation = await runMaterialValidation(recipe, parts);
     if (!validation.valid) {
       return c.json({ error: formatValidationError(validation) }, 400);
     }
@@ -224,7 +224,7 @@ app.post("/api/generate/:recipeId", async (c) => {
     const alchemist = resolveAlchemist(c);
     const parts = serverToMaterialParts(materials);
 
-    const validation = runMaterialValidation(recipe, parts);
+    const validation = await runMaterialValidation(recipe, parts);
     if (!validation.valid) {
       return c.json({ error: formatValidationError(validation) }, 400);
     }
@@ -342,7 +342,7 @@ app.post("/api/preview/:recipeId", async (c) => {
   try {
     const parts = serverToMaterialParts(materials);
 
-    const validation = runMaterialValidation(recipe, parts);
+    const validation = await runMaterialValidation(recipe, parts);
     if (!validation.valid) {
       return c.json({ error: formatValidationError(validation) }, 400);
     }

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -171,7 +171,7 @@ describe("evaluate + judgeMaterials", () => {
           {
             type: "text",
             min: 1,
-            evaluate: async (parts) => {
+            evaluate: async (_parts) => {
               await new Promise((r) => setTimeout(r, 1));
               return { score: 0.8, message: "Good quality" };
             },

--- a/packages/core/src/__tests__/validation.test.ts
+++ b/packages/core/src/__tests__/validation.test.ts
@@ -81,20 +81,20 @@ describe("validateMaterialRequirements", () => {
 });
 
 describe("runMaterialValidation", () => {
-  it("returns valid when no requirements or custom validator", () => {
-    const result = runMaterialValidation({}, []);
+  it("returns valid when no requirements or custom validator", async () => {
+    const result = await runMaterialValidation({}, []);
     expect(result.valid).toBe(true);
   });
 
-  it("runs declarative check only", () => {
-    const result = runMaterialValidation({ requiredMaterials: [{ type: "text", min: 1 }] }, [
+  it("runs declarative check only", async () => {
+    const result = await runMaterialValidation({ requiredMaterials: [{ type: "text", min: 1 }] }, [
       { type: "text", text: "hello" },
     ]);
     expect(result.valid).toBe(true);
   });
 
-  it("runs custom validator after declarative check passes", () => {
-    const result = runMaterialValidation(
+  it("runs custom validator after declarative check passes", async () => {
+    const result = await runMaterialValidation(
       {
         requiredMaterials: [{ type: "text", min: 1 }],
         validateMaterials: (parts) => {
@@ -111,9 +111,9 @@ describe("runMaterialValidation", () => {
     expect(result.message).toBe("Text must be at least 10 characters");
   });
 
-  it("skips custom validator when declarative check fails", () => {
+  it("skips custom validator when declarative check fails", async () => {
     let customCalled = false;
-    const result = runMaterialValidation(
+    const result = await runMaterialValidation(
       {
         requiredMaterials: [{ type: "image", min: 1 }],
         validateMaterials: () => {
@@ -127,8 +127,8 @@ describe("runMaterialValidation", () => {
     expect(customCalled).toBe(false);
   });
 
-  it("runs custom validator when no declarative requirements", () => {
-    const result = runMaterialValidation(
+  it("runs custom validator when no declarative requirements", async () => {
+    const result = await runMaterialValidation(
       {
         validateMaterials: () => ({ valid: false, message: "Custom error" }),
       },
@@ -136,5 +136,191 @@ describe("runMaterialValidation", () => {
     );
     expect(result.valid).toBe(false);
     expect(result.message).toBe("Custom error");
+  });
+});
+
+describe("evaluate + judgeMaterials", () => {
+  it("runs evaluate on matching parts and returns evaluations", async () => {
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [
+          {
+            type: "text",
+            min: 1,
+            label: "テキスト素材",
+            evaluate: (parts) => {
+              const len = (parts[0] as { type: "text"; text: string }).text.length;
+              return { score: Math.min(len / 100, 1) };
+            },
+          },
+        ],
+      },
+      [{ type: "text", text: "hello" }],
+    );
+    expect(result.valid).toBe(true);
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations?.[0].type).toBe("text");
+    expect(result.evaluations?.[0].label).toBe("テキスト素材");
+    expect(result.evaluations?.[0].evaluation.score).toBe(5 / 100);
+  });
+
+  it("supports async evaluate functions", async () => {
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [
+          {
+            type: "text",
+            min: 1,
+            evaluate: async (parts) => {
+              await new Promise((r) => setTimeout(r, 1));
+              return { score: 0.8, message: "Good quality" };
+            },
+          },
+        ],
+      },
+      [{ type: "text", text: "hello" }],
+    );
+    expect(result.valid).toBe(true);
+    expect(result.evaluations?.[0].evaluation).toEqual({ score: 0.8, message: "Good quality" });
+  });
+
+  it("skips evaluate when declarative check fails", async () => {
+    let evaluateCalled = false;
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [
+          {
+            type: "text",
+            min: 3,
+            evaluate: () => {
+              evaluateCalled = true;
+              return { score: 1 };
+            },
+          },
+        ],
+      },
+      [{ type: "text", text: "only one" }],
+    );
+    expect(result.valid).toBe(false);
+    expect(evaluateCalled).toBe(false);
+    expect(result.evaluations).toBeUndefined();
+  });
+
+  it("judgeMaterials returns canTransmute=false → valid=false", async () => {
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [
+          {
+            type: "text",
+            min: 1,
+            label: "課題感テキスト",
+            evaluate: () => ({ score: 0.1, message: "品質が低い" }),
+          },
+        ],
+        judgeMaterials: (evaluations) => {
+          const failed = evaluations.filter((e) => e.evaluation.score < 0.3);
+          if (failed.length > 0) {
+            return { canTransmute: false, message: `${failed[0].label}の品質が不足しています` };
+          }
+          return { canTransmute: true };
+        },
+      },
+      [{ type: "text", text: "x" }],
+    );
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe("課題感テキストの品質が不足しています");
+    expect(result.judgement?.canTransmute).toBe(false);
+    expect(result.evaluations).toHaveLength(1);
+  });
+
+  it("judgeMaterials returns canTransmute=true with warning", async () => {
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [
+          {
+            type: "text",
+            min: 1,
+            evaluate: () => ({ score: 0.4 }),
+          },
+        ],
+        judgeMaterials: (evaluations) => {
+          const avg = evaluations.reduce((s, e) => s + e.evaluation.score, 0) / evaluations.length;
+          if (avg < 0.5) {
+            return {
+              canTransmute: true,
+              warning: "素材の品質が低いため、精度が下がる可能性があります",
+            };
+          }
+          return { canTransmute: true };
+        },
+      },
+      [{ type: "text", text: "hello" }],
+    );
+    expect(result.valid).toBe(true);
+    expect(result.judgement?.canTransmute).toBe(true);
+    expect(result.judgement?.warning).toBe("素材の品質が低いため、精度が下がる可能性があります");
+  });
+
+  it("judgeMaterials is skipped when no evaluate functions exist", async () => {
+    let judgeCalled = false;
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [{ type: "text", min: 1 }],
+        judgeMaterials: () => {
+          judgeCalled = true;
+          return { canTransmute: true };
+        },
+      },
+      [{ type: "text", text: "hello" }],
+    );
+    expect(result.valid).toBe(true);
+    expect(judgeCalled).toBe(false);
+    expect(result.evaluations).toBeUndefined();
+  });
+
+  it("runs evaluate in parallel for multiple requirements", async () => {
+    const callOrder: string[] = [];
+    const result = await runMaterialValidation(
+      {
+        requiredMaterials: [
+          {
+            type: "text",
+            min: 1,
+            label: "テキスト",
+            evaluate: async () => {
+              callOrder.push("text-start");
+              await new Promise((r) => setTimeout(r, 10));
+              callOrder.push("text-end");
+              return { score: 0.9 };
+            },
+          },
+          {
+            type: "data",
+            min: 1,
+            label: "データ",
+            evaluate: async () => {
+              callOrder.push("data-start");
+              await new Promise((r) => setTimeout(r, 10));
+              callOrder.push("data-end");
+              return { score: 0.7 };
+            },
+          },
+        ],
+        judgeMaterials: (evaluations) => {
+          const avg = evaluations.reduce((s, e) => s + e.evaluation.score, 0) / evaluations.length;
+          return { canTransmute: true, warning: avg < 0.9 ? "Average below 0.9" : undefined };
+        },
+      },
+      [
+        { type: "text", text: "hello" },
+        { type: "data", format: "json" as const, content: "{}" },
+      ],
+    );
+    expect(result.valid).toBe(true);
+    expect(result.evaluations).toHaveLength(2);
+    expect(result.judgement?.warning).toBe("Average below 0.9");
+    // Parallel execution: both should start before either ends
+    expect(callOrder[0]).toBe("text-start");
+    expect(callOrder[1]).toBe("data-start");
   });
 });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -25,3 +25,12 @@ export class TransformError extends AlchemyError {
     this.name = "TransformError";
   }
 }
+
+export class MaterialValidationError extends AlchemyError {
+  readonly result: import("./types.js").MaterialValidationResult;
+  constructor(result: import("./types.js").MaterialValidationResult) {
+    super(result.message ?? result.judgement?.message ?? "Material validation failed");
+    this.name = "MaterialValidationError";
+    this.result = result;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,11 @@
 // Errors
-export { AlchemyError, RefineError, TransformError, TransmuteError } from "./errors.js";
+export {
+  AlchemyError,
+  MaterialValidationError,
+  RefineError,
+  TransformError,
+  TransmuteError,
+} from "./errors.js";
 // Material utilities
 export { extractAllText, extractText, isTextOnly, normalizeSpellOutput } from "./material.js";
 // MaterialInput
@@ -19,6 +25,9 @@ export type {
   ImageMaterialPart,
   KnownLanguage,
   Language,
+  MaterialEvaluation,
+  MaterialEvaluationEntry,
+  MaterialJudgement,
   MaterialPart,
   MaterialPartRegistry,
   MaterialPartType,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,7 +196,9 @@ export interface Recipe<TInput, TOutput> {
   refiner: Refiner<TOutput>;
   transforms?: MaterialTransform[];
   requiredMaterials?: MaterialRequirement[];
-  validateMaterials?: (parts: MaterialPart[]) => MaterialValidationResult;
+  validateMaterials?: (
+    parts: MaterialPart[],
+  ) => MaterialValidationResult | Promise<MaterialValidationResult>;
   /** 全素材の評価結果を見て錬成可否を判断 */
   judgeMaterials?: (evaluations: MaterialEvaluationEntry[]) => MaterialJudgement;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,6 +65,32 @@ export interface MaterialRequirement {
   readonly min?: number; // デフォルト: 1
   readonly max?: number; // undefined = 無制限
   readonly label?: string; // 表示用ラベル
+  /** 該当typeの素材を受けて品質スコアを返す */
+  readonly evaluate?: (parts: MaterialPart[]) => MaterialEvaluation | Promise<MaterialEvaluation>;
+}
+
+/** 個別素材の評価結果 */
+export interface MaterialEvaluation {
+  /** 0-1 の品質スコア */
+  score: number;
+  /** 評価メッセージ（例: "回答率が低いため精度が下がる可能性があります"） */
+  message?: string;
+}
+
+/** judge に渡される素材評価の集約エントリ */
+export interface MaterialEvaluationEntry {
+  type: MaterialPartType;
+  label?: string;
+  evaluation: MaterialEvaluation;
+}
+
+/** judge の判定結果 */
+export interface MaterialJudgement {
+  canTransmute: boolean;
+  /** canTransmute=true でも警告を出せる */
+  warning?: string;
+  /** canTransmute=false の理由 */
+  message?: string;
 }
 
 /** バリデーション結果 */
@@ -72,6 +98,10 @@ export interface MaterialValidationResult {
   valid: boolean;
   message?: string;
   issues?: MaterialValidationIssue[];
+  /** 各素材の品質スコア */
+  evaluations?: MaterialEvaluationEntry[];
+  /** 錬成可否判定 */
+  judgement?: MaterialJudgement;
 }
 
 export interface MaterialValidationIssue {
@@ -167,6 +197,8 @@ export interface Recipe<TInput, TOutput> {
   transforms?: MaterialTransform[];
   requiredMaterials?: MaterialRequirement[];
   validateMaterials?: (parts: MaterialPart[]) => MaterialValidationResult;
+  /** 全素材の評価結果を見て錬成可否を判断 */
+  judgeMaterials?: (evaluations: MaterialEvaluationEntry[]) => MaterialJudgement;
 }
 
 // ──────────────────────────────────────────
@@ -176,4 +208,6 @@ export interface Recipe<TInput, TOutput> {
 export interface AlchemistConfig {
   transmuter: Transmuter;
   transforms?: MaterialTransform[];
+  /** true にすると transmute() の先頭で素材バリデーションを自動実行 */
+  validateMaterials?: boolean;
 }

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -61,7 +61,9 @@ export function validateMaterialRequirements(
 export async function runMaterialValidation(
   recipe: {
     requiredMaterials?: MaterialRequirement[];
-    validateMaterials?: (parts: MaterialPart[]) => MaterialValidationResult;
+    validateMaterials?: (
+      parts: MaterialPart[],
+    ) => MaterialValidationResult | Promise<MaterialValidationResult>;
     judgeMaterials?: (evaluations: MaterialEvaluationEntry[]) => MaterialJudgement;
   },
   parts: MaterialPart[],
@@ -79,9 +81,20 @@ export async function runMaterialValidation(
   if (recipe.requiredMaterials) {
     const requirementsWithEvaluate = recipe.requiredMaterials.filter((r) => r.evaluate);
     if (requirementsWithEvaluate.length > 0) {
+      // Pre-group parts by type to avoid repeated O(parts) scans per requirement
+      const partsByType = new Map<string, MaterialPart[]>();
+      for (const part of parts) {
+        const arr = partsByType.get(part.type);
+        if (arr) {
+          arr.push(part);
+        } else {
+          partsByType.set(part.type, [part]);
+        }
+      }
+
       const evalResults = await Promise.all(
         requirementsWithEvaluate.map(async (req) => {
-          const matchingParts = parts.filter((p) => p.type === req.type);
+          const matchingParts = partsByType.get(req.type) ?? [];
           // biome-ignore lint/style/noNonNullAssertion: filtered above
           const evaluation = await req.evaluate!(matchingParts);
           return {
@@ -110,9 +123,13 @@ export async function runMaterialValidation(
 
   // 4. Custom function check
   if (recipe.validateMaterials) {
-    const customResult = recipe.validateMaterials(parts);
+    const customResult = await recipe.validateMaterials(parts);
     if (!customResult.valid) {
-      return { ...customResult, evaluations, judgement };
+      return {
+        ...customResult,
+        ...(evaluations !== undefined && { evaluations }),
+        ...(judgement !== undefined && { judgement }),
+      };
     }
   }
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,4 +1,6 @@
 import type {
+  MaterialEvaluationEntry,
+  MaterialJudgement,
   MaterialPart,
   MaterialRequirement,
   MaterialValidationIssue,
@@ -52,26 +54,67 @@ export function validateMaterialRequirements(
 }
 
 /**
- * Run both declarative (requiredMaterials) and custom (validateMaterials) validation.
- * Declarative check runs first; if it fails, custom check is skipped.
+ * Run both declarative (requiredMaterials) and custom (validateMaterials) validation,
+ * including evaluate and judgeMaterials when provided.
+ * Declarative check runs first; if it fails, subsequent checks are skipped.
  */
-export function runMaterialValidation(
+export async function runMaterialValidation(
   recipe: {
     requiredMaterials?: MaterialRequirement[];
     validateMaterials?: (parts: MaterialPart[]) => MaterialValidationResult;
+    judgeMaterials?: (evaluations: MaterialEvaluationEntry[]) => MaterialJudgement;
   },
   parts: MaterialPart[],
-): MaterialValidationResult {
-  // 1. Declarative check
+): Promise<MaterialValidationResult> {
+  // 1. Declarative check (型×個数)
   if (recipe.requiredMaterials && recipe.requiredMaterials.length > 0) {
     const result = validateMaterialRequirements(recipe.requiredMaterials, parts);
     if (!result.valid) return result;
   }
 
-  // 2. Custom function check
-  if (recipe.validateMaterials) {
-    return recipe.validateMaterials(parts);
+  // 2. Evaluate (各素材の品質スコア)
+  let evaluations: MaterialEvaluationEntry[] | undefined;
+  let judgement: MaterialJudgement | undefined;
+
+  if (recipe.requiredMaterials) {
+    const requirementsWithEvaluate = recipe.requiredMaterials.filter((r) => r.evaluate);
+    if (requirementsWithEvaluate.length > 0) {
+      const evalResults = await Promise.all(
+        requirementsWithEvaluate.map(async (req) => {
+          const matchingParts = parts.filter((p) => p.type === req.type);
+          // biome-ignore lint/style/noNonNullAssertion: filtered above
+          const evaluation = await req.evaluate!(matchingParts);
+          return {
+            type: req.type,
+            label: req.label,
+            evaluation,
+          } satisfies MaterialEvaluationEntry;
+        }),
+      );
+      evaluations = evalResults;
+    }
   }
 
-  return { valid: true };
+  // 3. Judge (錬成可否判定)
+  if (recipe.judgeMaterials && evaluations && evaluations.length > 0) {
+    judgement = recipe.judgeMaterials(evaluations);
+    if (!judgement.canTransmute) {
+      return {
+        valid: false,
+        message: judgement.message,
+        evaluations,
+        judgement,
+      };
+    }
+  }
+
+  // 4. Custom function check
+  if (recipe.validateMaterials) {
+    const customResult = recipe.validateMaterials(parts);
+    if (!customResult.valid) {
+      return { ...customResult, evaluations, judgement };
+    }
+  }
+
+  return { valid: true, evaluations, judgement };
 }

--- a/packages/node/src/__tests__/alchemist.test.ts
+++ b/packages/node/src/__tests__/alchemist.test.ts
@@ -4,7 +4,7 @@ import type {
   TransmutationResult,
   Transmuter,
 } from "@edv4h/alchemy-core";
-import { JsonRefiner, TextRefiner } from "@edv4h/alchemy-core";
+import { JsonRefiner, MaterialValidationError, TextRefiner } from "@edv4h/alchemy-core";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { Alchemist } from "../index.js";
@@ -330,5 +330,114 @@ describe("MaterialTransform pipeline", () => {
     const parts = (transmuter.stream as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as MaterialPart[];
     expect(parts[0]).toEqual({ type: "text", text: "STREAM-PREFIX" });
+  });
+});
+
+describe("Auto material validation (validateMaterials: true)", () => {
+  it("throws MaterialValidationError when requiredMaterials fail", async () => {
+    const transmuter = mockTransmuter("result");
+    const alchemist = new Alchemist({ transmuter, validateMaterials: true });
+
+    await expect(
+      alchemist.transmute(
+        {
+          id: "auto-validate",
+          requiredMaterials: [{ type: "image", min: 1 }],
+          spell: () => "no image here",
+          refiner: new TextRefiner(),
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(MaterialValidationError);
+    expect(transmuter.transmute).not.toHaveBeenCalled();
+  });
+
+  it("throws MaterialValidationError when judgeMaterials returns canTransmute=false", async () => {
+    const transmuter = mockTransmuter("result");
+    const alchemist = new Alchemist({ transmuter, validateMaterials: true });
+
+    try {
+      await alchemist.transmute(
+        {
+          id: "judge-fail",
+          requiredMaterials: [
+            {
+              type: "text",
+              min: 1,
+              label: "課題感",
+              evaluate: () => ({ score: 0.1 }),
+            },
+          ],
+          judgeMaterials: (evals) => {
+            const low = evals.find((e) => e.evaluation.score < 0.3);
+            return low
+              ? { canTransmute: false, message: `${low.label}の品質不足` }
+              : { canTransmute: true };
+          },
+          spell: () => "test",
+          refiner: new TextRefiner(),
+        },
+        undefined,
+      );
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(MaterialValidationError);
+      const err = e as MaterialValidationError;
+      expect(err.message).toBe("課題感の品質不足");
+      expect(err.result.judgement?.canTransmute).toBe(false);
+    }
+  });
+
+  it("does not validate when validateMaterials is false (default)", async () => {
+    const transmuter = mockTransmuter("result");
+    const alchemist = new Alchemist({ transmuter });
+
+    const result = await alchemist.transmute(
+      {
+        id: "no-auto-validate",
+        requiredMaterials: [{ type: "image", min: 1 }],
+        spell: () => "no image",
+        refiner: new TextRefiner(),
+      },
+      undefined,
+    );
+    expect(result).toBe("result");
+  });
+
+  it("passes validation and proceeds to transmute", async () => {
+    const transmuter = mockTransmuter("success");
+    const alchemist = new Alchemist({ transmuter, validateMaterials: true });
+
+    const result = await alchemist.transmute(
+      {
+        id: "valid-materials",
+        requiredMaterials: [{ type: "text", min: 1 }],
+        spell: (input: string) => input,
+        refiner: new TextRefiner(),
+      },
+      "hello world",
+    );
+    expect(result).toBe("success");
+    expect(transmuter.transmute).toHaveBeenCalled();
+  });
+
+  it("validates in stream() before yielding", async () => {
+    const transmuter: Transmuter = {
+      transmute: vi.fn(),
+      stream: vi.fn(),
+    };
+    const alchemist = new Alchemist({ transmuter, validateMaterials: true });
+
+    const gen = alchemist.stream(
+      {
+        id: "stream-validate",
+        requiredMaterials: [{ type: "image", min: 1 }],
+        spell: () => "no image",
+        refiner: new TextRefiner(),
+      },
+      undefined,
+    );
+    await expect(gen.next()).rejects.toThrow(MaterialValidationError);
+    expect(transmuter.stream).not.toHaveBeenCalled();
   });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -6,7 +6,12 @@ import type {
   Recipe,
   TransmutationOptions,
 } from "@edv4h/alchemy-core";
-import { normalizeSpellOutput, TransmuteError } from "@edv4h/alchemy-core";
+import {
+  MaterialValidationError,
+  normalizeSpellOutput,
+  runMaterialValidation,
+  TransmuteError,
+} from "@edv4h/alchemy-core";
 
 export class Alchemist {
   private config: AlchemistConfig;
@@ -25,6 +30,10 @@ export class Alchemist {
 
     const spellOutput = await recipe.spell(material);
     let parts = normalizeSpellOutput(spellOutput);
+
+    if (this.config.validateMaterials) {
+      await this.autoValidate(recipe, parts);
+    }
 
     const transforms = this.collectTransforms(recipe);
     if (transforms.length > 0) {
@@ -67,6 +76,10 @@ export class Alchemist {
 
     const spellOutput = await recipe.spell(material);
     let parts = normalizeSpellOutput(spellOutput);
+
+    if (this.config.validateMaterials) {
+      await this.autoValidate(recipe, parts);
+    }
 
     const transforms = this.collectTransforms(recipe);
     if (transforms.length > 0) {
@@ -117,6 +130,16 @@ export class Alchemist {
     return [...global, ...local];
   }
 
+  private async autoValidate<TInput, TOutput>(
+    recipe: Recipe<TInput, TOutput>,
+    parts: MaterialPart[],
+  ): Promise<void> {
+    const result = await runMaterialValidation(recipe, parts);
+    if (!result.valid) {
+      throw new MaterialValidationError(result);
+    }
+  }
+
   private async applyTransforms(
     parts: MaterialPart[],
     context: MaterialTransformContext,
@@ -140,6 +163,7 @@ export {
   filterByType,
   isTextOnly,
   JsonRefiner,
+  MaterialValidationError,
   MermaidRefiner,
   normalizeSpellOutput,
   prependText,


### PR DESCRIPTION
## Summary

- 素材ごとの品質スコア（0-1）を返す `evaluate` 関数を `MaterialRequirement` に追加
- 全素材の評価結果から錬成可否を判断する `Recipe.judgeMaterials` を追加
- `AlchemistConfig.validateMaterials: true` で `transmute()` / `stream()` 実行前に自動バリデーション
- `MaterialValidationError` で詳細な評価結果にアクセス可能
- **Minor breaking**: `runMaterialValidation` が async 化（`Promise<MaterialValidationResult>` を返す）

### 3層構造

```
素材ごと evaluate → score (0-1) + message
         ↓
レシピの judgeMaterials → 全素材の score を見て canTransmute / warning を判断
         ↓
Alchemist.transmute() → canTransmute=false なら throw
```

### 新しい型

| 型 | 説明 |
|---|---|
| `MaterialEvaluation` | `{ score: number; message?: string }` |
| `MaterialEvaluationEntry` | `{ type, label?, evaluation }` |
| `MaterialJudgement` | `{ canTransmute, warning?, message? }` |
| `MaterialValidationError` | `result` プロパティで詳細取得 |

## Test plan

- [x] evaluate が各素材に対して実行されスコアを返す
- [x] async evaluate 対応
- [x] evaluate が並列実行される
- [x] judgeMaterials で canTransmute=false → valid=false
- [x] judgeMaterials で canTransmute=true + warning
- [x] evaluate なし時に judgeMaterials がスキップされる
- [x] 型×個数チェック失敗時に evaluate がスキップされる
- [x] Alchemist auto-validation (transmute/stream)
- [x] validateMaterials=false (default) で既存動作に影響なし
- [x] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)