### PR TITLE
📝 docs: update docs-site for material evaluation system

### DIFF
--- a/examples/docs-site/api/index.html
+++ b/examples/docs-site/api/index.html
@@ -145,8 +145,8 @@
             <tr><td><code>temperature</code></td><td><code>number?</code></td><td>Sampling temperature (0–2)</td></tr>
             <tr><td><code>transforms</code></td><td><code>MaterialTransform[]?</code></td><td>Recipe-specific transforms</td></tr>
             <tr><td><code>requiredMaterials</code></td><td><code>MaterialRequirement[]?</code></td><td>Declarative material type requirements</td></tr>
-            <tr><td><code>validateMaterials</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialValidationResult | Promise&lt;MaterialValidationResult&gt;</code></td><td>Custom validation function (sync or async)</td></tr>
-            <tr><td><code>judgeMaterials</code></td><td><code>(evaluations: MaterialEvaluationEntry[]) =&gt; MaterialJudgement</code></td><td>Aggregate quality evaluation to decide transmute eligibility</td></tr>
+            <tr><td><code>validateMaterials</code></td><td><code>((parts: MaterialPart[]) =&gt; MaterialValidationResult | Promise&lt;MaterialValidationResult&gt;)?</code></td><td>Custom validation function (sync or async)</td></tr>
+            <tr><td><code>judgeMaterials</code></td><td><code>((evaluations: MaterialEvaluationEntry[]) =&gt; MaterialJudgement)?</code></td><td>Aggregate quality evaluation to decide transmute eligibility</td></tr>
           </tbody>
         </table>
 
@@ -165,7 +165,7 @@
             <tr><td><code>min</code></td><td><code>number?</code></td><td>Minimum count (default: 1)</td></tr>
             <tr><td><code>max</code></td><td><code>number?</code></td><td>Maximum count (undefined = unlimited)</td></tr>
             <tr><td><code>label</code></td><td><code>string?</code></td><td>Display label for error messages</td></tr>
-            <tr><td><code>evaluate</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialEvaluation | Promise&lt;MaterialEvaluation&gt;</code></td><td>Quality scoring function (0–1 score)</td></tr>
+            <tr><td><code>evaluate</code></td><td><code>((parts: MaterialPart[]) =&gt; MaterialEvaluation | Promise&lt;MaterialEvaluation&gt;)?</code></td><td>Quality scoring function (0–1 score)</td></tr>
           </tbody>
         </table>
 

--- a/examples/docs-site/api/index.html
+++ b/examples/docs-site/api/index.html
@@ -145,7 +145,8 @@
             <tr><td><code>temperature</code></td><td><code>number?</code></td><td>Sampling temperature (0–2)</td></tr>
             <tr><td><code>transforms</code></td><td><code>MaterialTransform[]?</code></td><td>Recipe-specific transforms</td></tr>
             <tr><td><code>requiredMaterials</code></td><td><code>MaterialRequirement[]?</code></td><td>Declarative material type requirements</td></tr>
-            <tr><td><code>validateMaterials</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialValidationResult</code></td><td>Custom validation function</td></tr>
+            <tr><td><code>validateMaterials</code></td><td><code>(parts) =&gt; MaterialValidationResult | Promise&lt;…&gt;</code></td><td>Custom validation function (sync or async)</td></tr>
+            <tr><td><code>judgeMaterials</code></td><td><code>(evaluations: MaterialEvaluationEntry[]) =&gt; MaterialJudgement</code></td><td>Aggregate quality evaluation to decide transmute eligibility</td></tr>
           </tbody>
         </table>
 
@@ -164,6 +165,7 @@
             <tr><td><code>min</code></td><td><code>number?</code></td><td>Minimum count (default: 1)</td></tr>
             <tr><td><code>max</code></td><td><code>number?</code></td><td>Maximum count (undefined = unlimited)</td></tr>
             <tr><td><code>label</code></td><td><code>string?</code></td><td>Display label for error messages</td></tr>
+            <tr><td><code>evaluate</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialEvaluation | Promise&lt;…&gt;</code></td><td>Quality scoring function (0–1 score)</td></tr>
           </tbody>
         </table>
 
@@ -173,7 +175,9 @@
           <tbody>
             <tr><td><code>valid</code></td><td><code>boolean</code></td><td>Whether validation passed</td></tr>
             <tr><td><code>message</code></td><td><code>string?</code></td><td>Human-readable message</td></tr>
-            <tr><td><code>issues</code></td><td><code>MaterialValidationIssue[]?</code></td><td>Detailed issue list</td></tr>
+            <tr><td><code>issues</code></td><td><code>MaterialValidationIssue[]?</code></td><td>Detailed issue list (type × count check)</td></tr>
+            <tr><td><code>evaluations</code></td><td><code>MaterialEvaluationEntry[]?</code></td><td>Per-material quality scores</td></tr>
+            <tr><td><code>judgement</code></td><td><code>MaterialJudgement?</code></td><td>Aggregate transmute eligibility</td></tr>
           </tbody>
         </table>
 
@@ -189,6 +193,38 @@
           </tbody>
         </table>
 
+        <h4 id="materialevaluation"><code>MaterialEvaluation</code></h4>
+        <p>Quality score returned by <code>evaluate</code> on a <code>MaterialRequirement</code>.</p>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>score</code></td><td><code>number</code></td><td>Quality score between 0 (worst) and 1 (best)</td></tr>
+            <tr><td><code>message</code></td><td><code>string?</code></td><td>Explanation (e.g. "Response rate is low")</td></tr>
+          </tbody>
+        </table>
+
+        <h4 id="materialevaluationentry"><code>MaterialEvaluationEntry</code></h4>
+        <p>Entry passed to <code>judgeMaterials</code>, grouping a requirement's type/label with its evaluation result.</p>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>type</code></td><td><code>MaterialPartType</code></td><td>Material type</td></tr>
+            <tr><td><code>label</code></td><td><code>string?</code></td><td>Label from the requirement</td></tr>
+            <tr><td><code>evaluation</code></td><td><code>MaterialEvaluation</code></td><td>The evaluation result</td></tr>
+          </tbody>
+        </table>
+
+        <h4 id="materialjudgement"><code>MaterialJudgement</code></h4>
+        <p>Result of <code>judgeMaterials</code>, deciding whether transmutation should proceed.</p>
+        <table class="param-table">
+          <thead><tr><th>Property</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>canTransmute</code></td><td><code>boolean</code></td><td>Whether to allow transmutation</td></tr>
+            <tr><td><code>warning</code></td><td><code>string?</code></td><td>Warning even when <code>canTransmute</code> is true</td></tr>
+            <tr><td><code>message</code></td><td><code>string?</code></td><td>Reason when <code>canTransmute</code> is false</td></tr>
+          </tbody>
+        </table>
+
         <h4 id="validatematerialrequirements"><code>validateMaterialRequirements(requirements, parts)</code></h4>
         <p>Validate material parts against declarative requirements.</p>
         <div class="code-block">
@@ -200,17 +236,25 @@
         </div>
 
         <h4 id="runmaterialvalidation"><code>runMaterialValidation(recipe, parts)</code></h4>
-        <p>Run both declarative (<code>requiredMaterials</code>) and custom (<code>validateMaterials</code>) validation. Declarative check runs first; if it fails, the custom check is skipped.</p>
+        <p>Run the full validation pipeline: declarative check → evaluate → judgeMaterials → custom validateMaterials. Each stage is skipped if the previous stage fails.</p>
         <div class="code-block">
           <div class="code-block-header"><span class="code-block-lang">ts</span></div>
-          <pre><code class="language-ts">function runMaterialValidation(
+          <pre><code class="language-ts">async function runMaterialValidation(
   recipe: {
     requiredMaterials?: MaterialRequirement[];
-    validateMaterials?: (parts: MaterialPart[]) =&gt; MaterialValidationResult;
+    validateMaterials?: (parts: MaterialPart[]) =&gt; MaterialValidationResult | Promise&lt;…&gt;;
+    judgeMaterials?: (evaluations: MaterialEvaluationEntry[]) =&gt; MaterialJudgement;
   },
   parts: MaterialPart[],
-): MaterialValidationResult;</code></pre>
+): Promise&lt;MaterialValidationResult&gt;;</code></pre>
         </div>
+        <p>Validation stages:</p>
+        <ol>
+          <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type</li>
+          <li><strong>Evaluate</strong> — runs each requirement's <code>evaluate()</code> in parallel, producing quality scores</li>
+          <li><strong>Judge</strong> — passes all evaluations to <code>judgeMaterials()</code> for transmute eligibility</li>
+          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> as a final filter</li>
+        </ol>
 
         <hr class="section-divider" />
 
@@ -270,6 +314,7 @@
             <tr><td><code>TransmuteError</code></td><td>LLM API call failure</td></tr>
             <tr><td><code>RefineError</code></td><td>Output parsing/validation failure</td></tr>
             <tr><td><code>TransformError</code></td><td>Material transform failure</td></tr>
+            <tr><td><code>MaterialValidationError</code></td><td>Material validation failure (has <code>result: MaterialValidationResult</code> property)</td></tr>
           </tbody>
         </table>
 
@@ -290,6 +335,7 @@
 interface AlchemistConfig {
   transmuter: Transmuter;
   transforms?: MaterialTransform[];
+  validateMaterials?: boolean; // Auto-validate before transmute/stream (default: false)
 }</code></pre>
         </div>
 

--- a/examples/docs-site/api/index.html
+++ b/examples/docs-site/api/index.html
@@ -145,7 +145,7 @@
             <tr><td><code>temperature</code></td><td><code>number?</code></td><td>Sampling temperature (0–2)</td></tr>
             <tr><td><code>transforms</code></td><td><code>MaterialTransform[]?</code></td><td>Recipe-specific transforms</td></tr>
             <tr><td><code>requiredMaterials</code></td><td><code>MaterialRequirement[]?</code></td><td>Declarative material type requirements</td></tr>
-            <tr><td><code>validateMaterials</code></td><td><code>(parts) =&gt; MaterialValidationResult | Promise&lt;…&gt;</code></td><td>Custom validation function (sync or async)</td></tr>
+            <tr><td><code>validateMaterials</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialValidationResult | Promise&lt;MaterialValidationResult&gt;</code></td><td>Custom validation function (sync or async)</td></tr>
             <tr><td><code>judgeMaterials</code></td><td><code>(evaluations: MaterialEvaluationEntry[]) =&gt; MaterialJudgement</code></td><td>Aggregate quality evaluation to decide transmute eligibility</td></tr>
           </tbody>
         </table>
@@ -165,7 +165,7 @@
             <tr><td><code>min</code></td><td><code>number?</code></td><td>Minimum count (default: 1)</td></tr>
             <tr><td><code>max</code></td><td><code>number?</code></td><td>Maximum count (undefined = unlimited)</td></tr>
             <tr><td><code>label</code></td><td><code>string?</code></td><td>Display label for error messages</td></tr>
-            <tr><td><code>evaluate</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialEvaluation | Promise&lt;…&gt;</code></td><td>Quality scoring function (0–1 score)</td></tr>
+            <tr><td><code>evaluate</code></td><td><code>(parts: MaterialPart[]) =&gt; MaterialEvaluation | Promise&lt;MaterialEvaluation&gt;</code></td><td>Quality scoring function (0–1 score)</td></tr>
           </tbody>
         </table>
 
@@ -236,7 +236,7 @@
         </div>
 
         <h4 id="runmaterialvalidation"><code>runMaterialValidation(recipe, parts)</code></h4>
-        <p>Run the full validation pipeline: declarative check → evaluate → judgeMaterials → custom validateMaterials. Each stage is skipped if the previous stage fails.</p>
+        <p>Run the validation pipeline: declarative check → evaluate → judgeMaterials → custom validateMaterials. Each stage runs only when configured, and is skipped if a previous stage fails.</p>
         <div class="code-block">
           <div class="code-block-header"><span class="code-block-lang">ts</span></div>
           <pre><code class="language-ts">async function runMaterialValidation(
@@ -248,12 +248,12 @@
   parts: MaterialPart[],
 ): Promise&lt;MaterialValidationResult&gt;;</code></pre>
         </div>
-        <p>Validation stages:</p>
+        <p>Validation stages (each runs only when configured, and is skipped if a previous stage fails):</p>
         <ol>
-          <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type</li>
-          <li><strong>Evaluate</strong> — runs each requirement's <code>evaluate()</code> in parallel, producing quality scores</li>
-          <li><strong>Judge</strong> — passes all evaluations to <code>judgeMaterials()</code> for transmute eligibility</li>
-          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> as a final filter</li>
+          <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type (if <code>requiredMaterials</code> is set)</li>
+          <li><strong>Evaluate</strong> — runs each requirement's <code>evaluate()</code> in parallel, producing quality scores (only for requirements with <code>evaluate</code>)</li>
+          <li><strong>Judge</strong> — passes evaluations to <code>judgeMaterials()</code> for transmute eligibility (only if evaluations exist and <code>judgeMaterials</code> is set)</li>
+          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> as a final filter (if provided)</li>
         </ol>
 
         <hr class="section-divider" />

--- a/examples/docs-site/api/index.html
+++ b/examples/docs-site/api/index.html
@@ -242,7 +242,7 @@
           <pre><code class="language-ts">async function runMaterialValidation(
   recipe: {
     requiredMaterials?: MaterialRequirement[];
-    validateMaterials?: (parts: MaterialPart[]) =&gt; MaterialValidationResult | Promise&lt;…&gt;;
+    validateMaterials?: (parts: MaterialPart[]) =&gt; MaterialValidationResult | Promise&lt;MaterialValidationResult&gt;;
     judgeMaterials?: (evaluations: MaterialEvaluationEntry[]) =&gt; MaterialJudgement;
   },
   parts: MaterialPart[],

--- a/examples/docs-site/concepts/index.html
+++ b/examples/docs-site/concepts/index.html
@@ -271,10 +271,44 @@ const summarizeRecipe: Recipe&lt;string, { summary: string; bullets: string[] }&
 };</code></pre>
         </div>
 
-        <p>Validation runs in two stages via <code>runMaterialValidation()</code>:</p>
+        <h4>Quality Scoring (evaluate &amp; judgeMaterials)</h4>
+        <p>Beyond presence/count checks, you can score each material's quality with <code>evaluate</code> and make aggregate decisions with <code>judgeMaterials</code>:</p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">ts</span>
+          </div>
+          <pre><code class="language-ts">const recipe: Recipe&lt;MaterialPart[], BrewResult&gt; = {
+  id: "find-theme",
+  requiredMaterials: [
+    {
+      type: "data", min: 1, label: "Engagement score",
+      evaluate: (parts) =&gt; {
+        const data = JSON.parse((parts[0] as DataMaterialPart).content);
+        return {
+          score: data.responseRate,
+          message: data.responseRate &lt; 0.5 ? "Low response rate" : undefined,
+        };
+      },
+    },
+  ],
+  judgeMaterials: (evaluations) =&gt; {
+    const failed = evaluations.filter((e) =&gt; e.evaluation.score &lt; 0.3);
+    if (failed.length &gt; 0) {
+      return { canTransmute: false, message: `${failed[0].label} quality is insufficient` };
+    }
+    return { canTransmute: true };
+  },
+  // ...
+};</code></pre>
+        </div>
+
+        <p>Validation runs in four stages via <code>runMaterialValidation()</code> (async):</p>
         <ol>
           <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type</li>
-          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> only if the declarative check passes</li>
+          <li><strong>Evaluate</strong> — runs each requirement's <code>evaluate()</code> in parallel, producing 0–1 quality scores</li>
+          <li><strong>Judge</strong> — passes all evaluations to <code>judgeMaterials()</code> to decide transmute eligibility</li>
+          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> as a final filter</li>
         </ol>
 
         <h2 id="alchemist">Alchemist</h2>
@@ -289,7 +323,8 @@ import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 const alchemist = new Alchemist({
   transmuter: new OpenAITransmuter({ apiKey: "..." }),
-  transforms: [dataToText()],  // Global transforms
+  transforms: [dataToText()],       // Global transforms
+  validateMaterials: true,           // Auto-validate before each transmute/stream
 });
 
 // Three ways to use the Alchemist:

--- a/examples/docs-site/concepts/index.html
+++ b/examples/docs-site/concepts/index.html
@@ -303,12 +303,12 @@ const summarizeRecipe: Recipe&lt;string, { summary: string; bullets: string[] }&
 };</code></pre>
         </div>
 
-        <p>Validation runs in four stages via <code>runMaterialValidation()</code> (async):</p>
+        <p>Validation runs up to four stages via <code>runMaterialValidation()</code> (async). Each stage runs only when configured, and is skipped if a previous stage fails:</p>
         <ol>
-          <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type</li>
-          <li><strong>Evaluate</strong> — runs each requirement's <code>evaluate()</code> in parallel, producing 0–1 quality scores</li>
-          <li><strong>Judge</strong> — passes all evaluations to <code>judgeMaterials()</code> to decide transmute eligibility</li>
-          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> as a final filter</li>
+          <li><strong>Declarative check</strong> — validates <code>requiredMaterials</code> counts by type (if <code>requiredMaterials</code> is set)</li>
+          <li><strong>Evaluate</strong> — runs each requirement's <code>evaluate()</code> in parallel, producing 0–1 quality scores (only for requirements with <code>evaluate</code>)</li>
+          <li><strong>Judge</strong> — passes evaluations to <code>judgeMaterials()</code> to decide transmute eligibility (only if evaluations exist and <code>judgeMaterials</code> is set)</li>
+          <li><strong>Custom check</strong> — runs <code>validateMaterials()</code> as a final filter (if provided)</li>
         </ol>
 
         <h2 id="alchemist">Alchemist</h2>

--- a/examples/docs-site/concepts/index.html
+++ b/examples/docs-site/concepts/index.html
@@ -318,7 +318,7 @@ const summarizeRecipe: Recipe&lt;string, { summary: string; bullets: string[] }&
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import { Alchemist } from "@edv4h/alchemy-node";
+          <pre><code class="language-ts">import { Alchemist, dataToText } from "@edv4h/alchemy-node";
 import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 const alchemist = new Alchemist({

--- a/examples/docs-site/examples/index.html
+++ b/examples/docs-site/examples/index.html
@@ -363,12 +363,12 @@ const imageAnalysisRecipe: Recipe&lt;MaterialPart[], { description: string }&gt;
   ],
 };
 
-// Validate before calling the API
+// Validate before calling the API (async)
 const materials: MaterialPart[] = [
   { type: "text", text: "What's in this photo?" },
 ];
 
-const validation = runMaterialValidation(imageAnalysisRecipe, materials);
+const validation = await runMaterialValidation(imageAnalysisRecipe, materials);
 
 if (!validation.valid) {
   console.error("Validation failed:");
@@ -381,8 +381,85 @@ if (!validation.valid) {
 }</code></pre>
         </div>
 
+        <h3>Quality Scoring (evaluate &amp; judgeMaterials)</h3>
+        <p>Score each material's quality on a 0–1 scale and let <code>judgeMaterials</code> decide whether to proceed.</p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">ts</span>
+          </div>
+          <pre><code class="language-ts">import type { Recipe, MaterialPart, DataMaterialPart, TextMaterialPart } from "@edv4h/alchemy-core";
+
+const recipe: Recipe&lt;MaterialPart[], AnalysisResult&gt; = {
+  id: "find-theme",
+  requiredMaterials: [
+    {
+      type: "data", min: 1, label: "Engagement score",
+      evaluate: (parts) =&gt; {
+        const data = JSON.parse((parts[0] as DataMaterialPart).content);
+        return {
+          score: data.responseRate,
+          message: data.responseRate &lt; 0.5 ? "Low response rate" : undefined,
+        };
+      },
+    },
+    {
+      type: "text", min: 1, label: "Issue description",
+      evaluate: (parts) =&gt; {
+        const len = (parts[0] as TextMaterialPart).text.length;
+        return { score: Math.min(len / 100, 1) };
+      },
+    },
+  ],
+  judgeMaterials: (evaluations) =&gt; {
+    const failed = evaluations.filter((e) =&gt; e.evaluation.score &lt; 0.3);
+    if (failed.length &gt; 0) {
+      return { canTransmute: false, message: `${failed[0].label} quality is insufficient` };
+    }
+    const avg = evaluations.reduce((s, e) =&gt; s + e.evaluation.score, 0) / evaluations.length;
+    if (avg &lt; 0.5) {
+      return { canTransmute: true, warning: "Material quality is low, accuracy may decrease" };
+    }
+    return { canTransmute: true };
+  },
+  spell: (material) =&gt; "Analyze the data and find themes",
+  refiner: new JsonRefiner(AnalysisSchema),
+};
+
+// The result includes evaluations and judgement
+const result = await runMaterialValidation(recipe, materials);
+if (result.judgement?.warning) {
+  console.warn(result.judgement.warning);
+}</code></pre>
+        </div>
+
+        <h3>Auto-Validation with Alchemist</h3>
+        <p>Enable <code>validateMaterials: true</code> on <code>AlchemistConfig</code> to automatically validate before each <code>transmute()</code> or <code>stream()</code> call. Throws <code>MaterialValidationError</code> on failure.</p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-block-lang">ts</span>
+          </div>
+          <pre><code class="language-ts">import { Alchemist, MaterialValidationError } from "@edv4h/alchemy-node";
+
+const alchemist = new Alchemist({
+  transmuter: new OpenAITransmuter(),
+  validateMaterials: true,
+});
+
+try {
+  const result = await alchemist.transmute(recipe, materials);
+} catch (e) {
+  if (e instanceof MaterialValidationError) {
+    console.error(e.message);           // "Engagement score quality is insufficient"
+    console.log(e.result.evaluations);  // Per-material scores
+    console.log(e.result.judgement);    // { canTransmute: false, message: "..." }
+  }
+}</code></pre>
+        </div>
+
         <h3>Custom Validation</h3>
-        <p>For more complex rules, use <code>validateMaterials</code> alongside or instead of <code>requiredMaterials</code>.</p>
+        <p>For more complex rules, use <code>validateMaterials</code> alongside or instead of <code>requiredMaterials</code>. Supports both sync and async functions.</p>
 
         <div class="code-block">
           <div class="code-block-header">

--- a/examples/docs-site/examples/index.html
+++ b/examples/docs-site/examples/index.html
@@ -388,7 +388,12 @@ if (!validation.valid) {
           <div class="code-block-header">
             <span class="code-block-lang">ts</span>
           </div>
-          <pre><code class="language-ts">import type { Recipe, MaterialPart, DataMaterialPart, TextMaterialPart } from "@edv4h/alchemy-core";
+          <pre><code class="language-ts">import { JsonRefiner, runMaterialValidation } from "@edv4h/alchemy-core";
+import type { Recipe, MaterialPart, DataMaterialPart, TextMaterialPart } from "@edv4h/alchemy-core";
+import { z } from "zod";
+
+const AnalysisSchema = z.object({ themes: z.array(z.string()) });
+type AnalysisResult = z.infer&lt;typeof AnalysisSchema&gt;;
 
 const recipe: Recipe&lt;MaterialPart[], AnalysisResult&gt; = {
   id: "find-theme",
@@ -426,6 +431,12 @@ const recipe: Recipe&lt;MaterialPart[], AnalysisResult&gt; = {
   refiner: new JsonRefiner(AnalysisSchema),
 };
 
+// Sample materials with a data part and text description
+const materials: MaterialPart[] = [
+  { type: "data", format: "json", content: '{"responseRate": 0.45}' },
+  { type: "text", text: "Team engagement has been declining since Q3" },
+];
+
 // The result includes evaluations and judgement
 const result = await runMaterialValidation(recipe, materials);
 if (result.judgement?.warning) {
@@ -441,6 +452,7 @@ if (result.judgement?.warning) {
             <span class="code-block-lang">ts</span>
           </div>
           <pre><code class="language-ts">import { Alchemist, MaterialValidationError } from "@edv4h/alchemy-node";
+import { OpenAITransmuter } from "@edv4h/alchemy-plugin-transmuter-openai";
 
 const alchemist = new Alchemist({
   transmuter: new OpenAITransmuter(),


### PR DESCRIPTION
## Summary

- API Reference: `MaterialEvaluation`, `MaterialEvaluationEntry`, `MaterialJudgement` 型のテーブル追加。`MaterialRequirement.evaluate`、`Recipe.judgeMaterials`、async `runMaterialValidation`、`MaterialValidationError`、`AlchemistConfig.validateMaterials` を反映
- Concepts: evaluate/judgeMaterials のコード例と4段階バリデーションパイプラインの説明を追加。Alchemist の自動バリデーション例を追加
- Examples: Quality Scoring セクション、Auto-Validation セクションを新規追加。既存の `runMaterialValidation` 呼び出しを `await` に修正

## Test plan

- [x] `pnpm build` — docs-site ビルド成功
- [x] `pnpm lint` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)